### PR TITLE
checkout rocket for building vendored

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,24 @@ jobs:
         toolchain: nightly
         override: true
         components: rustfmt, clippy
+
+    - name: Checkout Rocket
+      uses: actions/checkout@v2
+      with:
+        repository: SergioBenitez/Rocket
+        path: Rocket
+        ref: 8d4d01106e2e10b08100805d40bfa19a7357e900
+        submodules: true
+
       # `cargo check` command here will use installed `nightly`
       # as it is set as an "override" for current directory
     - name: Run cargo check
       uses: actions-rs/cargo@v1
       with:
         command: check
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Rocket"]
+	path = Rocket
+	url = https://github.com/SergioBenitez/Rocket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ rocket_cors = { git = "https://github.com/PhotonQuantum/rocket_cors", branch = "
 # this is vendored here by git path to also capture the dependancy used by rocket_cors, to prevent duplicate artifacts and a build issue.
 # The vendored repo must be checked out at revision 88d4d0110
 [patch."https://github.com/SergioBenitez/Rocket"]
-rocket = { path = "../Rocket/core/lib", features = ["tls"] }
-rocket_http = { path = "../Rocket/core/http", features = ["serde"] }
-rocket_codegen = { path = "../Rocket/core/codegen" }
+rocket = { path = "./Rocket/core/lib", features = ["tls"] }
+rocket_http = { path = "./Rocket/core/http", features = ["serde"] }
+rocket_codegen = { path = "./Rocket/core/codegen" }


### PR DESCRIPTION
checks out Rocket in CI to resolve a multiple-artifacts build issue (as rocket_cors also uses a git dependancy for Rocket)