### PR TITLE
orbit creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,20 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-std-resolver"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d613d619c2886fc0f4b5a777eceab405b23de82d73f0fc61ae402fdb9bc6fb2"
-dependencies = [
- "async-std",
- "async-trait",
- "futures-io",
- "futures-util",
- "pin-utils",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "async-task"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +1565,6 @@ version = "0.19.0"
 source = "git+https://github.com/ipfs-rust/ipfs-embed?rev=ba82076d4950c31f974425827635bfd0adb28c62#ba82076d4950c31f974425827635bfd0adb28c62"
 dependencies = [
  "anyhow",
- "async-global-executor",
  "async-io",
  "async-trait",
  "fnv",
@@ -1596,6 +1581,7 @@ dependencies = [
  "pin-project 1.0.7",
  "prometheus",
  "thiserror",
+ "tokio",
  "tracing",
  "void",
 ]
@@ -1696,7 +1682,6 @@ name = "kepler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "bs58",
  "did-pkh",
  "hex",
@@ -1710,6 +1695,7 @@ dependencies = [
  "serde_json",
  "ssi 0.2.0 (git+https://github.com/spruceid/ssi?rev=df98fabf6b86a816a0a2fb22b191f49f95e0a952)",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1945,7 +1931,6 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e63dab8b5ff35e0c101a3e51e843ba782c07bbb1682f5fd827622e0d02b98b"
 dependencies = [
- "async-std-resolver",
  "futures",
  "libp2p-core",
  "log",
@@ -2186,15 +2171,15 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
 dependencies = [
- "async-io",
  "futures",
  "futures-timer",
- "if-watch",
+ "if-addrs",
  "ipnet",
  "libc",
  "libp2p-core",
  "log",
  "socket2 0.4.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3952,6 +3937,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,6 +4029,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
+ "tokio",
  "url",
 ]
 
@@ -4052,6 +4049,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
  "hex",
  "ipfs-embed",
  "libipld",
+ "libp2p-core",
  "nom",
  "rocket",
  "rocket_cors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4"
 async-std = "1.9"
 libipld = "0.11"
 rocket_cors = { git = "https://github.com/PhotonQuantum/rocket_cors", branch = "master" }
+libp2p-core = "0.28"
 
 [dev-dependencies]
 did-pkh = "0.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 rocket = { git = "https://github.com/SergioBenitez/Rocket", rev = "8d4d01106e2e10b08100805d40bfa19a7357e900" }
-ipfs-embed = { git = "https://github.com/ipfs-rust/ipfs-embed", rev = "ba82076d4950c31f974425827635bfd0adb28c62" }
+ipfs-embed = { git = "https://github.com/ipfs-rust/ipfs-embed", rev = "ba82076d4950c31f974425827635bfd0adb28c62", default-features = false, features = ["tokio"] }
 anyhow = "1.0"
 ssi = { git = "https://github.com/spruceid/ssi", rev = "df98fabf6b86a816a0a2fb22b191f49f95e0a952", features = ["secp256k1", "secp256r1", "ripemd160", "keccak-hash"] }
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
@@ -18,10 +18,10 @@ bs58 = "0.4"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 hex = "0.4"
-async-std = "1.9"
 libipld = "0.11"
 rocket_cors = { git = "https://github.com/PhotonQuantum/rocket_cors", branch = "master" }
 libp2p-core = "0.28"
+tokio-stream = { version = "0.1", features = ["fs"] }
 
 [dev-dependencies]
 did-pkh = "0.0.1"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -36,7 +36,7 @@ pub enum Action {
 
 pub trait AuthorizationToken: Sized {
     type Policy: AuthorizationPolicy<Token = Self> + Send + Sync;
-    const header_key: &'static str;
+    const HEADER_KEY: &'static str;
     fn extract<'a, T: Iterator<Item = &'a str>>(auth_data: T) -> Result<Self>;
     fn action(&self) -> &Action;
 }
@@ -55,7 +55,7 @@ impl<'r, T: 'static + AuthorizationToken + Send + Sync> FromRequest<'r> for Auth
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         // get token from headers
-        let token = match T::extract(req.headers().get(T::header_key)) {
+        let token = match T::extract(req.headers().get(T::HEADER_KEY)) {
             Ok(t) => t,
             Err(e) => return Outcome::Failure((Status::Unauthorized, e)),
         };

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 use crate::{
     codec::SupportedCodecs,
     orbit::{Orbit, SimpleOrbit},
-    Orbits,
+    OrbitCollection, Orbits,
 };
 use anyhow::Result;
 use libipld::{
@@ -74,7 +74,7 @@ impl<'r, T: 'static + AuthorizationToken + Send + Sync> FromRequest<'r> for Auth
             Action::Put { orbit_id, content }
             | Action::Get { orbit_id, content }
             | Action::Del { orbit_id, content } => {
-                let read_orbits = orbits.orbits();
+                let read_orbits = orbits.orbits().await;
                 let orbit = match read_orbits.get(orbit_id) {
                     Some(o) => o,
                     None => {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,15 +1,12 @@
 use crate::{
-    codec::{PutContent, SupportedCodecs},
-    orbit::SimpleOrbit,
-    tz::{verify, TZAuth, TezosBasicAuthorization},
+    codec::SupportedCodecs,
+    orbit::{Orbit, SimpleOrbit},
     Orbits,
 };
 use anyhow::Result;
-use core::str::FromStr;
 use libipld::{
     cid::Cid,
-    codec::Codec,
-    multihash::{Code, Digest},
+    multihash::{Code, MultihashDigest},
 };
 use rocket::{
     http::Status,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,6 +13,7 @@ use rocket::{
     request::{FromRequest, Outcome, Request},
 };
 
+#[derive(Debug)]
 pub enum Action {
     Put {
         orbit_id: Cid,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,34 +1,39 @@
 use crate::{
-    codec::PutContent,
+    codec::{PutContent, SupportedCodecs},
     orbit::SimpleOrbit,
-    tz::{verify, TZAuth},
+    tz::{verify, TZAuth, TezosBasicAuthorization},
     Orbits,
 };
 use anyhow::Result;
 use core::str::FromStr;
-use libipld::cid::Cid;
+use libipld::{
+    cid::Cid,
+    codec::Codec,
+    multihash::{Code, Digest},
+};
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},
 };
 
-pub enum ContentAction {
-    Put(Vec<PutContent>),
-    Get(Vec<Cid>),
-    Del(Vec<Cid>),
-}
-
-pub struct CreateOrbit {
-    pkh: String,
-    action: Option<ContentAction>,
-}
-
 pub enum Action {
-    Content {
+    Put {
         orbit_id: Cid,
-        action: ContentAction,
+        content: Vec<Cid>,
     },
-    Orbit(CreateOrbit),
+    Get {
+        orbit_id: Cid,
+        content: Vec<Cid>,
+    },
+    Del {
+        orbit_id: Cid,
+        content: Vec<Cid>,
+    },
+    Create {
+        pkh: String,
+        salt: String,
+        put: Option<Vec<Cid>>,
+    },
 }
 
 pub trait AuthorizationToken: Sized {
@@ -40,7 +45,7 @@ pub trait AuthorizationToken: Sized {
 #[rocket::async_trait]
 pub trait AuthorizationPolicy {
     type Token: AuthorizationToken;
-    async fn authorize(&self, auth_token: &Self::Token) -> Result<ContentAction>;
+    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a Action>;
 }
 
 pub enum AuthToken {
@@ -48,21 +53,59 @@ pub enum AuthToken {
     TezosSignature(TZAuth),
 }
 
+pub struct AuthWrapper<T: AuthorizationToken>(T);
+
 #[rocket::async_trait]
-impl<'r> FromRequest<'r> for AuthToken {
+impl<'r, T: AuthorizationToken> FromRequest<'r> for AuthWrapper<T> {
     type Error = anyhow::Error;
 
-    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let auth_headers: Vec<&'r str> = request.headers().get("Authentication").collect();
-        match auth_headers.first() {
-            Some(auth_header) => match TZAuth::from_str(auth_header) {
-                Ok(tza) => match verify(&tza) {
-                    Ok(()) => Outcome::Success(Self::TezosSignature(tza)),
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        // get token from headers
+        let token = match T::extract(req.headers().get(T::header_key)) {
+            Ok(t) => t,
+            Err(e) => return Outcome::Failure((Status::Unauthorized, e)),
+        };
+        // get orbits state object
+        let orbits = match req.rocket().state::<Orbits<SimpleOrbit>>() {
+            Some(orbits) => orbits,
+            None => {
+                return Outcome::Failure((
+                    Status::Unauthorized,
+                    anyhow!("No authorization policy found"),
+                ))
+            }
+        };
+
+        match token.action() {
+            // content actions have the same authz process
+            Action::Put { orbit_id, content }
+            | Action::Get { orbit_id, content }
+            | Action::Del { orbit_id, content } => {
+                let orbit = match orbits.orbit(orbit_id) {
+                    Some(o) => o,
+                    None => {
+                        return Outcome::Failure((
+                            Status::Unauthorized,
+                            anyhow!("No authorization policy found"),
+                        ))
+                    }
+                };
+                match orbit.auth().authorize(&token) {
+                    Ok(_) => Outcome::Success(AuthWrapper(token)),
                     Err(e) => Outcome::Failure((Status::Unauthorized, e)),
-                },
-                Err(e) => Outcome::Failure((Status::Unauthorized, e)),
-            },
-            None => Outcome::Success(Self::None),
+                }
+            }
+            // Create actions dont have an existing orbit to authorize against, it's a node policy
+            // TODO have policy config, for now just be very permissive :shrug:
+            Action::Create { pkh, salt, put } => {
+                match req.rocket().state::<TezosBasicAuthorization>() {
+                    Some(auth) => match auth.authorize(&token) {
+                        Ok(_) => Outcome::Success(AuthWrapper(token)),
+                        Err(e) => Outcome::Failure((Status::Unauthorized, e)),
+                    },
+                    None => Outcome::Success(AuthWrapper(token)),
+                }
+            }
         }
     }
 }

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1,5 +1,5 @@
 use super::codec::SupportedCodecs;
-use libipld::cid::{Cid, Version};
+use libipld::cid::Cid;
 use rocket::tokio::io::AsyncRead;
 
 #[rocket::async_trait]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,5 +1,5 @@
 use rocket::{
-    data::{ByteUnit, DataStream, ToByteUnit},
+    data::{DataStream, ToByteUnit},
     form::{DataField, FromFormField, Result, ValueField},
     http::ContentType,
     request::{FromRequest, Outcome, Request},

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,12 +1,9 @@
 use super::cas::ContentAddressedStorage;
 use super::codec::SupportedCodecs;
-use ipfs_embed::{Ipfs, Key};
+use ipfs_embed::Ipfs;
 use libipld::{
     block::Block,
-    cid::{
-        multihash::{Code, MultihashDigest},
-        Cid,
-    },
+    cid::{multihash::Code, Cid},
     raw::RawCodec,
     store::DefaultParams,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use std::{
     str::FromStr,
 };
 use tokio_stream::wrappers::ReadDirStream;
+use tz::TezosBasicAuthorization;
 
 mod auth;
 mod cas;
@@ -182,6 +183,7 @@ async fn main() -> Result<()> {
 
     rocket::custom(rocket_config)
         .manage(load_orbits(path).await?)
+        .manage(TezosBasicAuthorization)
         .mount(
             "/",
             routes![get_content, put_content, batch_put_content, delete_content],

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,16 +194,12 @@ async fn batch_put_create(
     auth: AuthWrapper<TZAuth>,
 ) -> Result<String, Debug<Error>> {
     match auth.0.action() {
-        Action::Create { pkh, salt, put } => {
-            let orbit = create_orbit(
-                Cid::new_v1(
-                    SupportedCodecs::Raw as u64,
-                    Code::Blake3_256.digest([&pkh, ":", &salt].join("").as_bytes()),
-                ),
-                &orbits.base_path,
-                TezosBasicAuthorization,
-            )
-            .await?;
+        Action::Create {
+            orbit_id,
+            salt,
+            content,
+        } => {
+            let orbit = create_orbit(*orbit_id, &orbits.base_path, TezosBasicAuthorization).await?;
 
             let mut cids = Vec::<String>::new();
             for mut content in batch.into_inner().into_iter() {
@@ -231,16 +227,12 @@ async fn put_create(
     auth: AuthWrapper<TZAuth>,
 ) -> Result<String, Debug<Error>> {
     match auth.0.action() {
-        Action::Create { pkh, salt, put } => {
-            let orbit = create_orbit(
-                Cid::new_v1(
-                    SupportedCodecs::Raw as u64,
-                    Code::Blake3_256.digest([&pkh, ":", &salt].join("").as_bytes()),
-                ),
-                &orbits.base_path,
-                TezosBasicAuthorization,
-            )
-            .await?;
+        Action::Create {
+            orbit_id,
+            salt,
+            content,
+        } => {
+            let orbit = create_orbit(*orbit_id, &orbits.base_path, TezosBasicAuthorization).await?;
 
             let cid = orbit.put(&mut data.open(10u8.megabytes()), codec).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn delete_content(
     Ok(orbit.delete(&hash.0).await?)
 }
 
-#[async_std::main]
+#[rocket::main]
 async fn main() -> Result<()> {
     let rocket_config = rocket::Config::figment();
 
@@ -177,21 +177,18 @@ async fn main() -> Result<()> {
 
     let path = rocket_config
         .extract::<DBConfig>()
-        .expect("db path missing").db_path;
+        .expect("db path missing")
+        .db_path;
 
-    let orbits = load_orbits(path).await?;
-
-    rocket::tokio::runtime::Runtime::new()?
-        .spawn(
-            rocket::custom(rocket_config)
-                .manage(orbits)
-                .mount(
-                    "/",
-                    routes![get_content, put_content, batch_put_content, delete_content],
-                )
-                .attach(CorsOptions::default().to_cors()?)
-                .launch(),
+    rocket::custom(rocket_config)
+        .manage(load_orbits(path).await?)
+        .mount(
+            "/",
+            routes![get_content, put_content, batch_put_content, delete_content],
         )
-        .await??;
+        .attach(CorsOptions::default().to_cors()?)
+        .launch()
+        .await?;
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,33 +6,24 @@ extern crate anyhow;
 extern crate tokio;
 
 use anyhow::{anyhow, Error, Result};
-use libipld::{
-    cid::{multibase::Base, Cid},
-    store::StoreParams,
-};
+use libipld::cid::{multibase::Base, Cid};
 use rocket::{
-    data::{ByteUnit, Data, ToByteUnit},
-    fairing::Fairing,
+    data::{Data, ToByteUnit},
     form::Form,
-    futures::stream::{FuturesUnordered, Stream, StreamExt},
-    http::Status,
-    launch,
-    request::{FromRequest, Outcome, Request},
+    futures::stream::StreamExt,
     response::{Debug, Stream as RocketStream},
     tokio::fs::read_dir,
-    State,
 };
 use rocket_cors::CorsOptions;
 use serde::Deserialize;
 use std::{
     collections::BTreeMap,
-    io::{Cursor, Read},
-    iter::Extend,
+    io::Cursor,
     path::{Path, PathBuf},
     str::FromStr,
 };
 use tokio_stream::wrappers::ReadDirStream;
-use tz::TezosBasicAuthorization;
+use tz::{TZAuth, TezosBasicAuthorization};
 
 mod auth;
 mod cas;
@@ -44,7 +35,6 @@ mod tz;
 use auth::AuthToken;
 use cas::ContentAddressedStorage;
 use codec::{PutContent, SupportedCodecs};
-use ipfs_embed::{Config, DefaultParams, Ipfs, Multiaddr, PeerId};
 use orbit::{create_orbit, Orbit, SimpleOrbit};
 
 struct CidWrap(Cid);

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -1,22 +1,14 @@
-use crate::auth::AuthorizationPolicy;
-
 use super::{
-    auth::AuthorizationPolicy, cas::ContentAddressedStorage, codec::SupportedCodecs,
-    tz::TezosBasicAuthorization, CidWrap, Orbits,
+    auth::AuthorizationPolicy, cas::ContentAddressedStorage, codec::SupportedCodecs, CidWrap,
+    Orbits,
 };
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use ipfs_embed::{Config, Ipfs};
 use libipld::{
-    block::Block,
-    cid::{
-        multibase::Base,
-        multihash::{Code, MultihashDigest},
-        Cid,
-    },
-    raw::RawCodec,
+    cid::{multibase::Base, Cid},
     store::DefaultParams,
 };
-use libp2p_core::{PeerId, PublicKey};
+use libp2p_core::PeerId;
 use rocket::{
     futures::stream::StreamExt,
     http::Status,

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -1,6 +1,6 @@
 use super::{
     auth::AuthorizationPolicy, cas::ContentAddressedStorage, codec::SupportedCodecs, CidWrap,
-    Orbits,
+    OrbitCollection, Orbits,
 };
 use anyhow::{anyhow, Result};
 use ipfs_embed::{Config, Ipfs};
@@ -116,28 +116,5 @@ where
 
     async fn update(&self, update: Self::UpdateMessage) -> Result<(), <Self as Orbit>::Error> {
         todo!()
-    }
-}
-
-#[rocket::async_trait]
-impl<'r, A> FromRequest<'r> for &'r SimpleOrbit<A>
-where
-    A: 'static + AuthorizationPolicy + Send + Sync,
-{
-    type Error = anyhow::Error;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        match req.param::<CidWrap>(0) {
-            Some(Ok(oid)) => match req.rocket().state::<Orbits<SimpleOrbit<A>>>() {
-                Some(orbits) => match orbits.orbits().get(&oid.0) {
-                    Some(orbit) => Outcome::Success(orbit),
-                    None => Outcome::Failure((Status::NotFound, anyhow!("No Orbit"))),
-                },
-                // TODO check filesystem and init/cache if unused orbit db found
-                None => Outcome::Failure((Status::NotFound, anyhow!("No Orbit"))),
-            },
-            Some(Err(e)) => Outcome::Failure((Status::NotFound, e)),
-            None => Outcome::Failure((Status::NotFound, anyhow!("No Orbit"))),
-        }
     }
 }

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -78,7 +78,10 @@ where
     ) -> Result<Cid, <Self as ContentAddressedStorage>::Error> {
         self.ipfs.put(content, codec).await
     }
-    async fn get(&self, address: &Cid) -> Result<Option<Vec<u8>>, <Self as ContentAddressedStorage>::Error> {
+    async fn get(
+        &self,
+        address: &Cid,
+    ) -> Result<Option<Vec<u8>>, <Self as ContentAddressedStorage>::Error> {
         self.get(address).await
     }
     async fn delete(&self, address: &Cid) -> Result<(), <Self as ContentAddressedStorage>::Error> {
@@ -126,7 +129,7 @@ where
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         match req.param::<CidWrap>(0) {
             Some(Ok(oid)) => match req.rocket().state::<Orbits<SimpleOrbit<A>>>() {
-                Some(orbits) => match orbits.orbit(&oid.0) {
+                Some(orbits) => match orbits.orbits().get(&oid.0) {
                     Some(orbit) => Outcome::Success(orbit),
                     None => Outcome::Failure((Status::NotFound, anyhow!("No Orbit"))),
                 },

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -1,0 +1,57 @@
+use anyhow::{anyhow, Error, Result};
+use libp2p_core::{PublicKey, PeerId};
+use ssi::did::DIDURL;
+use super::{codec::SupportedCodecs, cas::ContentAddressedStorage, CidWrap, Orbits};
+use ipfs_embed::{Ipfs, Config};
+use rocket::{
+    http::Status,
+    request::{FromRequest, Outcome, Request},
+    futures::stream::StreamExt,
+    tokio::io::AsyncRead
+};
+use libipld::{
+    block::Block,
+    cid::{
+        multihash::{Code, MultihashDigest},
+        multibase::Base,
+        Cid,
+    },
+    raw::RawCodec,
+    store::DefaultParams,
+};
+use std::path::Path;
+
+#[rocket::async_trait]
+pub trait Orbit: ContentAddressedStorage {
+    type Error;
+    type UpdateMessage;
+
+    fn id(&self) -> &Cid;
+
+    fn hosts(&self) -> Vec<PeerId>;
+
+    fn admins(&self) -> &[&DIDURL];
+
+    async fn update(&self, update: Self::UpdateMessage) -> Result<(), <Self as ContentAddressedStorage>::Error>;
+}
+
+pub struct SimpleOrbit {
+    ipfs: Ipfs<DefaultParams>,
+    oid: Cid
+}
+
+pub async fn create_orbit<P: AsRef<Path>>(oid: Cid, path: P) -> Result<SimpleOrbit> {
+    let mut cfg = Config::new(
+        Some(path.as_ref().join(oid.to_string_of_base(Base::Base64Url)?)),
+        0,
+    );
+
+    // TODO enable dht once orbits are defined
+    cfg.network.kad = None;
+    let ipfs = Ipfs::<DefaultParams>::new(cfg).await?;
+    ipfs.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?
+    .next()
+    .await.ok_or(anyhow!("IPFS Listening Failed"));
+
+    Ok(SimpleOrbit { ipfs, oid })
+}

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -51,7 +51,7 @@ pub async fn create_orbit<P: AsRef<Path>>(oid: Cid, path: P) -> Result<SimpleOrb
     let ipfs = Ipfs::<DefaultParams>::new(cfg).await?;
     ipfs.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?
     .next()
-    .await.ok_or(anyhow!("IPFS Listening Failed"));
+    .await.ok_or(anyhow!("IPFS Listening Failed"))?;
 
     Ok(SimpleOrbit { ipfs, oid })
 }
@@ -102,7 +102,7 @@ impl<'r> FromRequest<'r> for &'r SimpleOrbit {
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         match req.param::<CidWrap>(0) {
-            Some(Ok(oid)) => match req.rocket().state::<Orbits<'_, SimpleOrbit>>() {
+            Some(Ok(oid)) => match req.rocket().state::<Orbits<SimpleOrbit>>() {
                 Some(orbits) => match orbits.orbit(&oid.0) {
                     Some(orbit) => Outcome::Success(orbit),
                     None => Outcome::Failure((Status::NotFound, anyhow!("No Orbit")))

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -1,4 +1,4 @@
-use crate::auth::{AuthorizationPolicy, AuthorizationToken};
+use crate::auth::{Action, AuthorizationPolicy, AuthorizationToken};
 use anyhow::Result;
 use bs58;
 use hex;

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -1,3 +1,4 @@
+use crate::auth::{AuthorizationPolicy, AuthorizationToken};
 use anyhow::Result;
 use bs58;
 use hex;
@@ -65,6 +66,18 @@ impl TZAuth {
             .digest(&encode_string(&message))
             .digest()
             .to_vec()
+    }
+}
+
+impl AuthorizationToken for TZAuth {
+    const header_key: &'static str = "Authorization";
+
+    fn extract<'a, T: Iterator<Item = &'a str>>(auth_data: T) -> Result<Self> {
+        todo!()
+    }
+
+    fn action(&self) -> &Action {
+        todo!()
     }
 }
 
@@ -146,6 +159,17 @@ pub fn from_tezos_key(tz_pk: &str) -> Result<JWK> {
         x509_thumbprint_sha256: None,
         params,
     })
+}
+
+pub struct TezosBasicAuthorization;
+
+#[rocket::async_trait]
+impl AuthorizationPolicy for TezosBasicAuthorization {
+    type Token = TZAuth;
+
+    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a ContentAction> {
+        verify(auth_token).map(|_| auth_token.action())
+    }
 }
 
 #[test]

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -71,6 +71,7 @@ impl TZAuth {
 
 impl AuthorizationToken for TZAuth {
     const header_key: &'static str = "Authorization";
+    type Policy = TezosBasicAuthorization;
 
     fn extract<'a, T: Iterator<Item = &'a str>>(auth_data: T) -> Result<Self> {
         todo!()
@@ -167,7 +168,7 @@ pub struct TezosBasicAuthorization;
 impl AuthorizationPolicy for TezosBasicAuthorization {
     type Token = TZAuth;
 
-    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a ContentAction> {
+    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a Action> {
         verify(auth_token).map(|_| auth_token.action())
     }
 }


### PR DESCRIPTION
Adds functionality for creating an orbit by POSTing content to `/`. Request contents are the same as putting content into an orbit except that the authorization header contains information used to generate the orbit ID.
Orbit IDs are generated using a domain secret, a nonce and the public key hash of the administrator in the form of a CID, made over the string `pkh:domain:nonce` with the `raw` codec.
Additionally, this PR refactors authorization into a set of related traits, AuthorizationPolicy and AuthorizationToken, as well as adds an Orbit trait with a simple implementation (mostly stubbed right now).
Orbits exist on disk in a directory specified by the `ROCKET_DB_PATH` environment variable at start time.
For Batch insertion on Orbit creation to work, PR #16 must be merged.
Currently all orbits must be the same type due to how Rocket implements state guards, however there is only one trait implementation at this time and a workaround is in progress.