### PR TITLE
use base58check for CID string representations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn batch_put_content(
                 .put(&mut content.content, content.codec)
                 .await
                 .map_or("".into(), |cid| {
-                    cid.to_string_of_base(Base::Base64Url)
+                    cid.to_string_of_base(Base::Base58Btc)
                         .map_or("".into(), |s| s)
                 }),
         );
@@ -180,7 +180,7 @@ async fn put_content(
         .ok_or(anyhow!("No Orbit Found"))?;
     match orbit.put(&mut data.open(10u8.megabytes()), codec).await {
         Ok(cid) => Ok(cid
-            .to_string_of_base(Base::Base64Url)
+            .to_string_of_base(Base::Base58Btc)
             .map_err(|e| anyhow!(e))?),
         Err(e) => Err(e)?,
     }
@@ -206,7 +206,7 @@ async fn batch_put_create(
                 cids.push(orbit.put(&mut content.content, content.codec).await.map_or(
                     "".into(),
                     |cid| {
-                        cid.to_string_of_base(Base::Base64Url)
+                        cid.to_string_of_base(Base::Base58Btc)
                             .map_or("".into(), |s| s)
                     },
                 ));
@@ -239,7 +239,7 @@ async fn put_create(
             orbits.add(orbit);
 
             Ok(cid
-                .to_string_of_base(Base::Base64Url)
+                .to_string_of_base(Base::Base58Btc)
                 .map_err(|e| anyhow!(e))?)
         }
         _ => Err(anyhow!("Invalid Authorization"))?,

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -50,7 +50,7 @@ where
     P: AsRef<Path>,
 {
     let mut cfg = Config::new(
-        Some(path.as_ref().join(oid.to_string_of_base(Base::Base64Url)?)),
+        Some(path.as_ref().join(oid.to_string_of_base(Base::Base58Btc)?)),
         0,
     );
 

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -130,12 +130,12 @@ fn serialize_action(action: &Action) -> Result<String> {
             content,
             salt,
         } => Ok([
-            &orbit_id.to_string_of_base(Base::Base64Url)?,
+            &orbit_id.to_string_of_base(Base::Base58Btc)?,
             "CREATE",
             &salt,
             &content
                 .iter()
-                .map(|c| c.to_string_of_base(Base::Base64Url))
+                .map(|c| c.to_string_of_base(Base::Base58Btc))
                 .collect::<Result<Vec<String>, libipld::cid::Error>>()?
                 .join(" "),
         ]
@@ -145,11 +145,11 @@ fn serialize_action(action: &Action) -> Result<String> {
 
 fn serialize_content_action(action: &str, orbit_id: &Cid, content: &[Cid]) -> Result<String> {
     Ok([
-        &orbit_id.to_string_of_base(Base::Base64Url)?,
+        &orbit_id.to_string_of_base(Base::Base58Btc)?,
         action,
         &content
             .iter()
-            .map(|c| c.to_string_of_base(Base::Base64Url))
+            .map(|c| c.to_string_of_base(Base::Base58Btc))
             .collect::<Result<Vec<String>, libipld::cid::Error>>()?
             .join(" "),
     ]


### PR DESCRIPTION
uses `base58check` as the default string encoding for CIDs and OIDs