### PR TITLE
better structure

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,262 @@
+use anyhow::Result;
+use rocket::{
+    data::{Data, ToByteUnit},
+    fairing::AdHoc,
+    figment::Figment,
+    form::Form,
+    http::{Header, Status},
+    response::Stream,
+    Build, Rocket, State,
+};
+use ssi::did::DIDURL;
+use std::{io::Cursor, path::PathBuf};
+
+use crate::auth::{Action, AuthWrapper, AuthorizationToken};
+use crate::cas::{CidWrap, ContentAddressedStorage};
+use crate::codec::{PutContent, SupportedCodecs};
+use crate::config::Config;
+use crate::orbit::{
+    create_orbit, load_orbits, verify_oid_v0, Orbit, OrbitCollection, Orbits, SimpleOrbit,
+};
+use crate::tz::{TezosAuthorizationString, TezosBasicAuthorization};
+
+#[get("/<orbit_id>/<hash>")]
+async fn get_content(
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit_id: CidWrap,
+    hash: CidWrap,
+    _auth: Option<AuthWrapper<TezosAuthorizationString>>,
+) -> Result<Option<Stream<Cursor<Vec<u8>>>>, (Status, &'static str)> {
+    let orbits_read = orbits.orbits().await;
+    let orbit = orbits_read
+        .get(&orbit_id.0)
+        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
+    match orbit.get(&hash.0).await {
+        Ok(Some(content)) => Ok(Some(Stream::chunked(Cursor::new(content), 1024))),
+        Ok(None) => Ok(None),
+        Err(_) => Ok(None),
+    }
+}
+
+#[post("/<orbit_id>", format = "multipart/form-data", data = "<batch>")]
+async fn batch_put_content(
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit_id: CidWrap,
+    batch: Form<Vec<PutContent>>,
+    _auth: AuthWrapper<TezosAuthorizationString>,
+) -> Result<String, (Status, &'static str)> {
+    let orbits_read = orbits.orbits().await;
+    let orbit = orbits_read
+        .get(&orbit_id.0)
+        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
+    let mut uris = Vec::<String>::new();
+    for content in batch.into_inner().into_iter() {
+        uris.push(
+            orbit
+                .put(&content.content, content.codec)
+                .await
+                .map_or("".into(), |cid| {
+                    orbit.make_uri(&cid).map_or("".into(), |s| s)
+                }),
+        );
+    }
+    Ok(uris.join("\n"))
+}
+
+#[post("/<orbit_id>", data = "<data>", rank = 2)]
+async fn put_content(
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit_id: CidWrap,
+    data: Data,
+    codec: SupportedCodecs,
+    _auth: AuthWrapper<TezosAuthorizationString>,
+) -> Result<String, (Status, &'static str)> {
+    let orbits_read = orbits.orbits().await;
+    let orbit = orbits_read
+        .get(&orbit_id.0)
+        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
+    match orbit
+        .put(
+            &data
+                .open(1u8.megabytes())
+                .into_bytes()
+                .await
+                .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
+            codec,
+        )
+        .await
+    {
+        Ok(cid) => Ok(orbit
+            .make_uri(&cid)
+            .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?),
+        Err(_) => Err((Status::InternalServerError, "Failed to store content")),
+    }
+}
+
+#[post("/", format = "multipart/form-data", data = "<batch>")]
+async fn batch_put_create(
+    // TODO find a good way to not restrict all orbits to the same Type
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    batch: Form<Vec<PutContent>>,
+    auth: AuthWrapper<TezosAuthorizationString>,
+) -> Result<String, (Status, &'static str)> {
+    match auth.0.action() {
+        Action::Create {
+            orbit_id,
+            parameters,
+            ..
+        } => {
+            verify_oid_v0(orbit_id, &auth.0.pkh, parameters)
+                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
+
+            let vm = DIDURL {
+                did: format!("did:pkh:tz:{}", &auth.0.pkh),
+                fragment: Some("TezosMethod2021".to_string()),
+                ..Default::default()
+            };
+
+            let orbit = create_orbit(
+                *orbit_id,
+                &orbits.base_path,
+                TezosBasicAuthorization,
+                vec![vm],
+                auth.0.to_string().as_bytes(),
+            )
+            .await
+            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
+
+            let mut uris = Vec::<String>::new();
+            for content in batch.into_inner().into_iter() {
+                uris.push(
+                    orbit
+                        .put(&content.content, content.codec)
+                        .await
+                        .map_or("".into(), |cid| {
+                            orbit.make_uri(&cid).map_or("".into(), |s| s)
+                        }),
+                );
+            }
+            orbits.add(orbit).await;
+            Ok(uris.join("\n"))
+        }
+        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
+    }
+}
+
+#[post("/", data = "<data>", rank = 2)]
+async fn put_create(
+    // TODO find a good way to not restrict all orbits to the same Type
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    data: Data,
+    codec: SupportedCodecs,
+    auth: AuthWrapper<TezosAuthorizationString>,
+) -> Result<String, (Status, &'static str)> {
+    match auth.0.action() {
+        Action::Create {
+            orbit_id,
+            parameters,
+            ..
+        } => {
+            verify_oid_v0(orbit_id, &auth.0.pkh, parameters)
+                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
+
+            let vm = DIDURL {
+                did: format!("did:pkh:tz:{}", &auth.0.pkh),
+                fragment: Some("TezosMethod2021".to_string()),
+                ..Default::default()
+            };
+
+            let orbit = create_orbit(
+                *orbit_id,
+                &orbits.base_path,
+                TezosBasicAuthorization,
+                vec![vm],
+                auth.0.to_string().as_bytes(),
+            )
+            .await
+            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
+
+            let uri = orbit
+                .make_uri(
+                    &orbit
+                        .put(
+                            &data
+                                .open(1u8.megabytes())
+                                .into_bytes()
+                                .await
+                                .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
+                            codec,
+                        )
+                        .await
+                        .map_err(|_| (Status::InternalServerError, "Failed to store content"))?,
+                )
+                .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?;
+
+            orbits.add(orbit).await;
+
+            Ok(uri)
+        }
+        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
+    }
+}
+
+#[delete("/<orbit_id>/<hash>")]
+async fn delete_content(
+    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit_id: CidWrap,
+    hash: CidWrap,
+    _auth: AuthWrapper<TezosAuthorizationString>,
+) -> Result<(), (Status, &'static str)> {
+    let orbits_read = orbits.orbits().await;
+    let orbit = orbits_read
+        .get(&orbit_id.0)
+        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
+    Ok(orbit
+        .delete(&hash.0)
+        .await
+        .map_err(|_| (Status::InternalServerError, "Failed to delete content"))?)
+}
+
+#[options("/<_s..>")]
+async fn cors(_s: PathBuf) -> () {
+    ()
+}
+
+pub async fn app(config: Figment) -> Result<Rocket<Build>> {
+    let kepler_config = config.extract::<Config>()?;
+
+    // ensure KEPLER_DATABASE_PATH exists
+    if !kepler_config.database.path.is_dir() {
+        return Err(anyhow!(
+            "KEPLER_DATABASE_PATH does not exist or is not a directory: {:?}",
+            kepler_config.database.path.to_str()
+        ));
+    }
+
+    Ok(rocket::custom(config)
+        .manage(load_orbits(kepler_config.database.path).await?)
+        .manage(TezosBasicAuthorization)
+        .mount(
+            "/",
+            routes![
+                get_content,
+                put_content,
+                batch_put_content,
+                delete_content,
+                put_create,
+                batch_put_create,
+                cors
+            ],
+        )
+        .attach(AdHoc::on_response("CORS", |_, resp| {
+            Box::pin(async move {
+                resp.set_header(Header::new("Access-Control-Allow-Origin", "*"));
+                resp.set_header(Header::new(
+                    "Access-Control-Allow-Methods",
+                    "POST, GET, OPTIONS, DELETE",
+                ));
+                resp.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+                resp.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
+            })
+        })))
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,4 @@
-use crate::{
-    orbit::{Orbit, SimpleOrbit},
-    OrbitCollection, Orbits,
-};
+use crate::orbit::{Orbit, OrbitCollection, Orbits, SimpleOrbit};
 use anyhow::Result;
 use libipld::cid::Cid;
 use rocket::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,63 @@
+#[macro_use]
+extern crate anyhow;
+#[macro_use]
+extern crate rocket;
+
+use anyhow::Result;
+use rocket::{fairing::AdHoc, figment::Figment, http::Header, Build, Rocket};
+
+pub mod auth;
+pub mod cas;
+pub mod codec;
+pub mod config;
+pub mod ipfs;
+pub mod lib;
+pub mod orbit;
+pub mod routes;
+pub mod tz;
+
+use crate::config::Config;
+use crate::orbit::load_orbits;
+use crate::routes::{
+    batch_put_content, batch_put_create, cors, delete_content, get_content, put_content, put_create,
+};
+use crate::tz::TezosBasicAuthorization;
+
+pub async fn app(config: Figment) -> Result<Rocket<Build>> {
+    let kepler_config = config.extract::<Config>()?;
+
+    // ensure KEPLER_DATABASE_PATH exists
+    if !kepler_config.database.path.is_dir() {
+        return Err(anyhow!(
+            "KEPLER_DATABASE_PATH does not exist or is not a directory: {:?}",
+            kepler_config.database.path.to_str()
+        ));
+    }
+
+    Ok(rocket::custom(config)
+        .manage(load_orbits(kepler_config.database.path).await?)
+        .manage(TezosBasicAuthorization)
+        .mount(
+            "/",
+            routes![
+                get_content,
+                put_content,
+                batch_put_content,
+                delete_content,
+                put_create,
+                batch_put_create,
+                cors
+            ],
+        )
+        .attach(AdHoc::on_response("CORS", |_, resp| {
+            Box::pin(async move {
+                resp.set_header(Header::new("Access-Control-Allow-Origin", "*"));
+                resp.set_header(Header::new(
+                    "Access-Control-Allow-Methods",
+                    "POST, GET, OPTIONS, DELETE",
+                ));
+                resp.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+                resp.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
+            })
+        })))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,18 +6,12 @@ extern crate anyhow;
 extern crate tokio;
 
 use anyhow::Result;
-use rocket::{
-    data::{Data, ToByteUnit},
-    fairing::AdHoc,
-    figment::providers::{Env, Format, Serialized, Toml},
-    form::Form,
-    http::{Header, Status},
-    response::Stream,
-    State,
+use rocket::figment::{
+    providers::{Env, Format, Serialized, Toml},
+    Figment,
 };
-use ssi::did::DIDURL;
-use std::{io::Cursor, path::PathBuf};
 
+mod app;
 mod auth;
 mod cas;
 mod codec;
@@ -26,269 +20,24 @@ mod ipfs;
 mod orbit;
 mod tz;
 
-use auth::{Action, AuthWrapper, AuthorizationToken};
-use cas::{CidWrap, ContentAddressedStorage};
-use codec::{PutContent, SupportedCodecs};
-use orbit::{
-    create_orbit, load_orbits, verify_oid_v0, Orbit, OrbitCollection, Orbits, SimpleOrbit,
-};
-use tz::{TezosAuthorizationString, TezosBasicAuthorization};
-
-#[get("/<orbit_id>/<hash>")]
-async fn get_content(
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
-    hash: CidWrap,
-    _auth: Option<AuthWrapper<TezosAuthorizationString>>,
-) -> Result<Option<Stream<Cursor<Vec<u8>>>>, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
-    match orbit.get(&hash.0).await {
-        Ok(Some(content)) => Ok(Some(Stream::chunked(Cursor::new(content), 1024))),
-        Ok(None) => Ok(None),
-        Err(_) => Ok(None),
-    }
-}
-
-#[post("/<orbit_id>", format = "multipart/form-data", data = "<batch>")]
-async fn batch_put_content(
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
-    batch: Form<Vec<PutContent>>,
-    _auth: AuthWrapper<TezosAuthorizationString>,
-) -> Result<String, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
-    let mut uris = Vec::<String>::new();
-    for content in batch.into_inner().into_iter() {
-        uris.push(
-            orbit
-                .put(&content.content, content.codec)
-                .await
-                .map_or("".into(), |cid| {
-                    orbit.make_uri(&cid).map_or("".into(), |s| s)
-                }),
-        );
-    }
-    Ok(uris.join("\n"))
-}
-
-#[post("/<orbit_id>", data = "<data>", rank = 2)]
-async fn put_content(
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
-    data: Data,
-    codec: SupportedCodecs,
-    _auth: AuthWrapper<TezosAuthorizationString>,
-) -> Result<String, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
-    match orbit
-        .put(
-            &data
-                .open(1u8.megabytes())
-                .into_bytes()
-                .await
-                .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
-            codec,
-        )
-        .await
-    {
-        Ok(cid) => Ok(orbit
-            .make_uri(&cid)
-            .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?),
-        Err(_) => Err((Status::InternalServerError, "Failed to store content")),
-    }
-}
-
-#[post("/", format = "multipart/form-data", data = "<batch>")]
-async fn batch_put_create(
-    // TODO find a good way to not restrict all orbits to the same Type
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    batch: Form<Vec<PutContent>>,
-    auth: AuthWrapper<TezosAuthorizationString>,
-) -> Result<String, (Status, &'static str)> {
-    match auth.0.action() {
-        Action::Create {
-            orbit_id,
-            parameters,
-            ..
-        } => {
-            verify_oid_v0(orbit_id, &auth.0.pkh, parameters)
-                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
-
-            let vm = DIDURL {
-                did: format!("did:pkh:tz:{}", &auth.0.pkh),
-                fragment: Some("TezosMethod2021".to_string()),
-                ..Default::default()
-            };
-
-            let orbit = create_orbit(
-                *orbit_id,
-                &orbits.base_path,
-                TezosBasicAuthorization,
-                vec![vm],
-                auth.0.to_string().as_bytes(),
-            )
-            .await
-            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
-
-            let mut uris = Vec::<String>::new();
-            for content in batch.into_inner().into_iter() {
-                uris.push(
-                    orbit
-                        .put(&content.content, content.codec)
-                        .await
-                        .map_or("".into(), |cid| {
-                            orbit.make_uri(&cid).map_or("".into(), |s| s)
-                        }),
-                );
-            }
-            orbits.add(orbit).await;
-            Ok(uris.join("\n"))
-        }
-        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
-    }
-}
-
-#[post("/", data = "<data>", rank = 2)]
-async fn put_create(
-    // TODO find a good way to not restrict all orbits to the same Type
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    data: Data,
-    codec: SupportedCodecs,
-    auth: AuthWrapper<TezosAuthorizationString>,
-) -> Result<String, (Status, &'static str)> {
-    match auth.0.action() {
-        Action::Create {
-            orbit_id,
-            parameters,
-            ..
-        } => {
-            verify_oid_v0(orbit_id, &auth.0.pkh, parameters)
-                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
-
-            let vm = DIDURL {
-                did: format!("did:pkh:tz:{}", &auth.0.pkh),
-                fragment: Some("TezosMethod2021".to_string()),
-                ..Default::default()
-            };
-
-            let orbit = create_orbit(
-                *orbit_id,
-                &orbits.base_path,
-                TezosBasicAuthorization,
-                vec![vm],
-                auth.0.to_string().as_bytes(),
-            )
-            .await
-            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
-
-            let uri = orbit
-                .make_uri(
-                    &orbit
-                        .put(
-                            &data
-                                .open(1u8.megabytes())
-                                .into_bytes()
-                                .await
-                                .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
-                            codec,
-                        )
-                        .await
-                        .map_err(|_| (Status::InternalServerError, "Failed to store content"))?,
-                )
-                .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?;
-
-            orbits.add(orbit).await;
-
-            Ok(uri)
-        }
-        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
-    }
-}
-
-#[delete("/<orbit_id>/<hash>")]
-async fn delete_content(
-    orbits: State<'_, Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
-    hash: CidWrap,
-    _auth: AuthWrapper<TezosAuthorizationString>,
-) -> Result<(), (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
-    Ok(orbit
-        .delete(&hash.0)
-        .await
-        .map_err(|_| (Status::InternalServerError, "Failed to delete content"))?)
-}
-
-#[options("/<_s..>")]
-async fn cors(_s: PathBuf) -> () {
-    ()
-}
+use app::app;
 
 #[rocket::main]
-async fn main() {
-    let config = rocket::figment::Figment::from(rocket::Config::default())
+async fn main() -> Result<()> {
+    let config = Figment::from(rocket::Config::default())
         .merge(Serialized::defaults(config::Config::default()))
         .merge(Toml::file("kepler.toml").nested())
         .merge(Env::prefixed("KEPLER_").split("_").global())
         .merge(Env::prefixed("ROCKET_").global()); // That's just for easy access to ROCKET_LOG_LEVEL
 
-    let kepler_config = config.extract::<config::Config>().unwrap();
-
-    // ensure KEPLER_DATABASE_PATH exists
-    if !kepler_config.database.path.is_dir() {
-        panic!(
-            "KEPLER_DATABASE_PATH does not exist or is not a directory: {}",
-            kepler_config.database.path.to_str().unwrap()
-        );
-    }
-
-    rocket::custom(config.clone())
-        .manage(load_orbits(kepler_config.database.path).await.unwrap())
-        .manage(TezosBasicAuthorization)
-        .mount(
-            "/",
-            routes![
-                get_content,
-                put_content,
-                batch_put_content,
-                delete_content,
-                put_create,
-                batch_put_create,
-                cors
-            ],
-        )
-        .attach(AdHoc::on_response("CORS", |_, resp| {
-            Box::pin(async move {
-                resp.set_header(Header::new("Access-Control-Allow-Origin", "*"));
-                resp.set_header(Header::new(
-                    "Access-Control-Allow-Methods",
-                    "POST, GET, OPTIONS, DELETE",
-                ));
-                resp.set_header(Header::new("Access-Control-Allow-Headers", "*"));
-                resp.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
-            })
-        }))
-        .launch()
-        .await
-        .unwrap();
+    Ok(app(config).await?.launch().await?)
 }
 
 #[test]
 #[should_panic]
 async fn test_form() {
-    use rocket::{http::ContentType, local::asynchronous::Client};
+    use codec::PutContent;
+    use rocket::{form::Form, http::ContentType, local::asynchronous::Client};
 
     #[post("/", format = "multipart/form-data", data = "<form>")]
     async fn stub_batch(form: Form<Vec<PutContent>>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,29 +6,17 @@ extern crate anyhow;
 extern crate tokio;
 
 use anyhow::Result;
-use libipld::cid::Cid;
 use rocket::{
     data::{Data, ToByteUnit},
     fairing::AdHoc,
     figment::providers::{Env, Format, Serialized, Toml},
-    form::{DataField, Form, FromFormField},
-    futures::stream::StreamExt,
+    form::Form,
     http::{Header, Status},
-    response::Stream as RocketStream,
-    tokio::fs::read_dir,
+    response::Stream,
     State,
 };
 use ssi::did::DIDURL;
-// use rocket_cors::CorsOptions;
-use std::{
-    collections::BTreeMap,
-    io::Cursor,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-use tokio::sync::{RwLock, RwLockReadGuard};
-use tokio_stream::wrappers::ReadDirStream;
-use tz::{TezosAuthorizationString, TezosBasicAuthorization};
+use std::{io::Cursor, path::PathBuf};
 
 mod auth;
 mod cas;
@@ -39,97 +27,12 @@ mod orbit;
 mod tz;
 
 use auth::{Action, AuthWrapper, AuthorizationToken};
-use cas::ContentAddressedStorage;
+use cas::{CidWrap, ContentAddressedStorage};
 use codec::{PutContent, SupportedCodecs};
-use orbit::{create_orbit, load_orbit, verify_oid_v0, Orbit, SimpleOrbit};
-
-#[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct CidWrap(Cid);
-
-// Orphan rule requires a wrapper type for this :(
-impl<'a> rocket::request::FromParam<'a> for CidWrap {
-    type Error = anyhow::Error;
-    fn from_param(param: &'a str) -> Result<CidWrap> {
-        Ok(CidWrap(Cid::from_str(param)?))
-    }
-}
-
-#[rocket::async_trait]
-impl<'r> FromFormField<'r> for CidWrap {
-    async fn from_data(field: DataField<'r, '_>) -> rocket::form::Result<'r, Self> {
-        Ok(CidWrap(
-            field
-                .name
-                .source()
-                .parse()
-                .map_err(|_| field.unexpected())?,
-        ))
-    }
-}
-
-struct Orbits<O>
-where
-    O: Orbit,
-{
-    pub stores: RwLock<BTreeMap<Cid, O>>,
-    pub base_path: PathBuf,
-}
-
-#[rocket::async_trait]
-pub trait OrbitCollection<O: Orbit> {
-    async fn orbits(&self) -> RwLockReadGuard<BTreeMap<Cid, O>>;
-    async fn add(&self, orbit: O) -> ();
-}
-
-impl<O: Orbit> Orbits<O> {
-    fn new<P: AsRef<Path>>(path: P) -> Self {
-        Self {
-            stores: RwLock::new(BTreeMap::new()),
-            base_path: path.as_ref().to_path_buf(),
-        }
-    }
-}
-
-#[rocket::async_trait]
-impl<O: Orbit> OrbitCollection<O> for Orbits<O> {
-    async fn orbits(&self) -> RwLockReadGuard<BTreeMap<Cid, O>> {
-        self.stores.read().await
-    }
-
-    // fn orbit(&self, id: &Cid) -> Option<&O> {
-    //     self.stores.read().expect("read orbit set").get(id)
-    // }
-
-    async fn add(&self, orbit: O) {
-        let mut lock = self.stores.write().await;
-        lock.insert(*orbit.id(), orbit);
-    }
-}
-
-async fn load_orbits<P: AsRef<Path>>(
-    path: P,
-) -> Result<Orbits<SimpleOrbit<TezosBasicAuthorization>>> {
-    let path_ref: &Path = path.as_ref();
-    let orbits = Orbits::new(path_ref);
-    // for entries in the dir
-    let orbit_list: Vec<SimpleOrbit<TezosBasicAuthorization>> =
-        ReadDirStream::new(read_dir(path_ref).await?)
-            // try to load each as an orbit
-            .filter_map(|p| async {
-                load_orbit(p.ok()?.file_name().to_str()?, TezosBasicAuthorization)
-                    .await
-                    .ok()
-            })
-            // load them all
-            .collect()
-            .await;
-
-    for orbit in orbit_list.into_iter() {
-        orbits.add(orbit).await
-    }
-
-    Ok(orbits)
-}
+use orbit::{
+    create_orbit, load_orbits, verify_oid_v0, Orbit, OrbitCollection, Orbits, SimpleOrbit,
+};
+use tz::{TezosAuthorizationString, TezosBasicAuthorization};
 
 #[get("/<orbit_id>/<hash>")]
 async fn get_content(
@@ -137,13 +40,13 @@ async fn get_content(
     orbit_id: CidWrap,
     hash: CidWrap,
     _auth: Option<AuthWrapper<TezosAuthorizationString>>,
-) -> Result<Option<RocketStream<Cursor<Vec<u8>>>>, (Status, &'static str)> {
+) -> Result<Option<Stream<Cursor<Vec<u8>>>>, (Status, &'static str)> {
     let orbits_read = orbits.orbits().await;
     let orbit = orbits_read
         .get(&orbit_id.0)
         .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     match orbit.get(&hash.0).await {
-        Ok(Some(content)) => Ok(Some(RocketStream::chunked(Cursor::new(content), 1024))),
+        Ok(Some(content)) => Ok(Some(Stream::chunked(Cursor::new(content), 1024))),
         Ok(None) => Ok(None),
         Err(_) => Ok(None),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,10 @@
-#[macro_use]
-extern crate rocket;
-#[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate tokio;
-
 use anyhow::Result;
 use rocket::figment::{
     providers::{Env, Format, Serialized, Toml},
     Figment,
 };
 
-mod app;
-mod auth;
-mod cas;
-mod codec;
-mod config;
-mod ipfs;
-mod orbit;
-mod tz;
-
-use app::app;
+use kepler::app;
 
 #[rocket::main]
 async fn main() -> Result<()> {

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -1,4 +1,7 @@
-use super::{auth::AuthorizationPolicy, cas::ContentAddressedStorage, codec::SupportedCodecs};
+use crate::{
+    auth::AuthorizationPolicy, cas::ContentAddressedStorage, codec::SupportedCodecs,
+    tz::TezosBasicAuthorization,
+};
 use anyhow::{anyhow, Result};
 use ipfs_embed::{Config, Ipfs};
 use libipld::{
@@ -10,10 +13,22 @@ use libipld::{
     store::DefaultParams,
 };
 use libp2p_core::PeerId;
-use rocket::{futures::stream::StreamExt, http::uri::Absolute, tokio::fs};
+use rocket::{
+    futures::stream::StreamExt,
+    http::uri::Absolute,
+    tokio::{
+        fs,
+        sync::{RwLock, RwLockReadGuard},
+    },
+};
 use serde::{Deserialize, Serialize};
 use ssi::did::DIDURL;
-use std::{convert::TryFrom, path::Path};
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    path::{Path, PathBuf},
+};
+use tokio_stream::wrappers::ReadDirStream;
 
 #[derive(Serialize, Deserialize)]
 pub struct OrbitMetadata {
@@ -220,4 +235,68 @@ where
     async fn update(&self, _update: Self::UpdateMessage) -> Result<(), <Self as Orbit>::Error> {
         todo!()
     }
+}
+
+pub struct Orbits<O>
+where
+    O: Orbit,
+{
+    pub stores: RwLock<BTreeMap<Cid, O>>,
+    pub base_path: PathBuf,
+}
+
+#[rocket::async_trait]
+pub trait OrbitCollection<O: Orbit> {
+    async fn orbits(&self) -> RwLockReadGuard<BTreeMap<Cid, O>>;
+    async fn add(&self, orbit: O) -> ();
+}
+
+impl<O: Orbit> Orbits<O> {
+    fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            stores: RwLock::new(BTreeMap::new()),
+            base_path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl<O: Orbit> OrbitCollection<O> for Orbits<O> {
+    async fn orbits(&self) -> RwLockReadGuard<BTreeMap<Cid, O>> {
+        self.stores.read().await
+    }
+
+    // fn orbit(&self, id: &Cid) -> Option<&O> {
+    //     self.stores.read().expect("read orbit set").get(id)
+    // }
+
+    async fn add(&self, orbit: O) {
+        let mut lock = self.stores.write().await;
+        lock.insert(*orbit.id(), orbit);
+    }
+}
+
+pub async fn load_orbits<P: AsRef<Path>>(
+    path: P,
+) -> Result<Orbits<SimpleOrbit<TezosBasicAuthorization>>> {
+    let path_ref: &Path = path.as_ref();
+    let orbits = Orbits::new(path_ref);
+    // for entries in the dir
+    let orbit_list: Vec<SimpleOrbit<TezosBasicAuthorization>> =
+        ReadDirStream::new(fs::read_dir(path_ref).await?)
+            // try to load each as an orbit
+            .filter_map(|p| async {
+                load_orbit(p.ok()?.file_name().to_str()?, TezosBasicAuthorization)
+                    .await
+                    .ok()
+            })
+            // load them all
+            .collect()
+            .await;
+
+    for orbit in orbit_list.into_iter() {
+        orbits.add(orbit).await
+    }
+
+    Ok(orbits)
 }


### PR DESCRIPTION
refactors the structure of the project a little bit:
- move `CidWrap` and trait implementations to `src/cas.rs`
- move `Orbits` and `OrbitCollections` to `src/orbit.rs`
- move all routes to `src/routes.rs`
- add `src/lib.rs` as root of the library crate, exposing all kepler modules
- move server init/config/building to `src/lib.rs`
- use `src/main.rs` only for launching the server

There are no logic or functionality changes