### PR TITLE
load using file path instead of file name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ async fn load_orbits<P: AsRef<Path>>(
         ReadDirStream::new(read_dir(path_ref).await?)
             // try to load each as an orbit
             .filter_map(|p| async {
-                load_orbit(p.ok()?.file_name().to_str()?, TezosBasicAuthorization)
+                load_orbit(p.ok()?.path().to_str()?, TezosBasicAuthorization)
                     .await
                     .ok()
             })


### PR DESCRIPTION
`load_orbits` would attempt to use the file name instead of file path for loading the databases. This PR fixes that.