### PR TITLE
List orbit contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "rocket"
 version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?branch=master#1f1976f8bf8531daf4ac596d83ea7ad589dd7368"
+source = "git+https://github.com/SergioBenitez/Rocket?branch=master#f1ecb79a7ea536bacc7b7e92d33bf5406c0c635f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3329,10 +3329,12 @@ dependencies = [
  "rocket_codegen",
  "rocket_http",
  "serde",
+ "serde_json",
  "state",
  "tempfile",
  "time 0.2.26",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "ubyte",
  "version_check",
@@ -3342,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "rocket_codegen"
 version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?branch=master#1f1976f8bf8531daf4ac596d83ea7ad589dd7368"
+source = "git+https://github.com/SergioBenitez/Rocket?branch=master#f1ecb79a7ea536bacc7b7e92d33bf5406c0c635f"
 dependencies = [
  "devise",
  "glob",
@@ -3357,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "rocket_http"
 version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?branch=master#1f1976f8bf8531daf4ac596d83ea7ad589dd7368"
+source = "git+https://github.com/SergioBenitez/Rocket?branch=master#f1ecb79a7ea536bacc7b7e92d33bf5406c0c635f"
 dependencies = [
  "cookie",
  "either",
@@ -3977,9 +3979,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 ipfs-embed = { git = "https://github.com/ipfs-rust/ipfs-embed", rev = "ba82076d4950c31f974425827635bfd0adb28c62", default-features = false, features = ["tokio"] }
-rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "master" }
+rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "master", features = ["json"] }
 anyhow = "1.0"
 ssi = { git = "https://github.com/spruceid/ssi", branch = "fix/tz2_verification", features = ["secp256k1", "secp256r1", "ripemd160", "keccak-hash"] }
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -28,6 +28,9 @@ pub enum Action {
         parameters: String,
         content: Vec<Cid>,
     },
+    List {
+        orbit_id: Cid,
+    },
 }
 
 pub trait AuthorizationToken: Sized {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -80,6 +80,7 @@ impl<'r, T: 'static + AuthorizationToken + Send + Sync> FromRequest<'r> for Auth
             // content actions have the same authz process
             Action::Put { orbit_id, .. }
             | Action::Get { orbit_id, .. }
+            | Action::List { orbit_id }
             | Action::Del { orbit_id, .. } => {
                 let read_orbits = orbits.orbits().await;
                 let orbit = match read_orbits.get(orbit_id) {

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -7,4 +7,5 @@ pub trait ContentAddressedStorage: Send + Sync {
     async fn put(&self, content: &[u8], codec: SupportedCodecs) -> Result<Cid, Self::Error>;
     async fn get(&self, address: &Cid) -> Result<Option<Vec<u8>>, Self::Error>;
     async fn delete(&self, address: &Cid) -> Result<(), Self::Error>;
+    async fn list(&self) -> Result<Vec<Cid>, Self::Error>;
 }

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -30,4 +30,11 @@ impl ContentAddressedStorage for Ipfs<DefaultParams> {
         self.remove_record(&address.hash().to_bytes().into());
         Ok(())
     }
+    async fn list(&self) -> Result<Vec<Cid>, Self::Error> {
+        // return a list of all CIDs which are aliased/pinned
+        self.iter().map(|i| {
+            i.filter(|c| self.reverse_alias(&c).map(|o| o.is_some()).unwrap_or(false))
+                .collect()
+        })
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use rocket::{
     form::{DataField, Form, FromFormField},
     futures::stream::StreamExt,
     http::{Header, Status},
+    serde::json::Json,
     tokio::fs::read_dir,
     State,
 };
@@ -134,7 +135,7 @@ async fn list_content(
     orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
     orbit_id: CidWrap,
     _auth: Option<AuthWrapper<TezosAuthorizationString>>,
-) -> Result<String, (Status, &'static str)> {
+) -> Result<Json<Vec<String>>, (Status, &'static str)> {
     let orbits_read = orbits.orbits().await;
     let orbit = orbits_read
         .get(&orbit_id.0)
@@ -150,7 +151,7 @@ async fn list_content(
                         .map_err(|_| (Status::InternalServerError, "Failed to serialize CID"))
                 })
                 .collect::<Result<Vec<String>, (Status, &'static str)>>()
-                .map(|v| v.join("\n"))
+                .map(|v| Json(v))
         })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate anyhow;
 extern crate tokio;
 
 use anyhow::Result;
-use libipld::cid::{multibase::Base, Cid};
+use libipld::cid::Cid;
 use rocket::{
     data::{Data, ToByteUnit},
     fairing::AdHoc,
@@ -147,7 +147,8 @@ async fn list_content(
         .and_then(|l| {
             l.into_iter()
                 .map(|c| {
-                    c.to_string_of_base(Base::Base58Btc)
+                    orbit
+                        .make_uri(&c)
                         .map_err(|_| (Status::InternalServerError, "Failed to serialize CID"))
                 })
                 .collect::<Result<Vec<String>, (Status, &'static str)>>()

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -196,6 +196,9 @@ where
     async fn delete(&self, address: &Cid) -> Result<(), <Self as ContentAddressedStorage>::Error> {
         self.delete(address).await
     }
+    async fn list(&self) -> Result<Vec<Cid>, <Self as ContentAddressedStorage>::Error> {
+        self.list().await
+    }
 }
 
 #[rocket::async_trait]

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -194,10 +194,10 @@ where
         ContentAddressedStorage::get(&self.ipfs, address).await
     }
     async fn delete(&self, address: &Cid) -> Result<(), <Self as ContentAddressedStorage>::Error> {
-        self.delete(address).await
+        self.ipfs.delete(address).await
     }
     async fn list(&self) -> Result<Vec<Cid>, <Self as ContentAddressedStorage>::Error> {
-        self.list().await
+        self.ipfs.list().await
     }
 }
 

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -70,6 +70,11 @@ fn parse_cid(s: &str) -> IResult<&str, Cid> {
         .map(|cid| ("", cid))
 }
 
+fn parse_list(s: &str) -> IResult<&str, Action> {
+    tuple((map_parser(take_until(" "), parse_cid), tag(" LIST")))(s)
+        .map(|(rest, (orbit_id, _))| (rest, Action::List { orbit_id }))
+}
+
 fn parse_get(s: &str) -> IResult<&str, Action> {
     tuple((
         map_parser(take_until(" "), parse_cid),
@@ -117,7 +122,7 @@ fn parse_create(s: &str) -> IResult<&str, Action> {
 }
 
 fn parse_action(s: &str) -> IResult<&str, Action> {
-    alt((parse_get, parse_put, parse_del, parse_create))(s)
+    alt((parse_get, parse_put, parse_del, parse_create, parse_list))(s)
 }
 
 fn serialize_action(action: &Action) -> Result<String> {
@@ -125,6 +130,7 @@ fn serialize_action(action: &Action) -> Result<String> {
         Action::Put { orbit_id, content } => serialize_content_action("PUT", orbit_id, content),
         Action::Get { orbit_id, content } => serialize_content_action("GET", orbit_id, content),
         Action::Del { orbit_id, content } => serialize_content_action("DEL", orbit_id, content),
+        Action::List { orbit_id } => serialize_content_action("LIST", orbit_id, &[]),
         Action::Create {
             orbit_id,
             content,


### PR DESCRIPTION
Adds a `List` operation, which will return a list of all CIDs in the orbit which are pinned/aliased. For DAG structures, this means only the head of the DAG will be returned. The format of the request is a `GET` request on the orbit ID path, i.e. `GET https://<host_url>/<orbit_id>`.