### PR TITLE
dont listen with ipfs nodes

### DIFF
--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -114,10 +114,6 @@ where
     // TODO enable dht once orbits are defined
     cfg.network.kad = None;
     let ipfs = Ipfs::<DefaultParams>::new(cfg).await?;
-    ipfs.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?
-        .next()
-        .await;
-    // .ok_or_else(|| anyhow!("IPFS Listening Failed"))?;
 
     Ok(SimpleOrbit { ipfs, oid, policy })
 }
@@ -135,10 +131,6 @@ where
     // TODO enable dht once orbits are defined
     cfg.network.kad = None;
     let ipfs = Ipfs::<DefaultParams>::new(cfg).await?;
-    ipfs.listen_on("/ip4/127.0.0.1/tcp/0".parse()?)?
-        .next()
-        .await
-        .ok_or_else(|| anyhow!("IPFS Listening Failed"))?;
 
     Ok(SimpleOrbit {
         ipfs,


### PR DESCRIPTION
each IPFS node listening on port `0` would cause the next to fail, leaving only one orbit existing at any one time. Currently there is no need to listen, this was left over from when `ipfs-embed` required a listen call to set `network.enabled` to true and allow it to work.