### PR TITLE
On-demand (cached) loading and decouple types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,9 +483,33 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2afe73808fbaac302e39c9754bfc3c4b4d0f99c9c240b9f4e4efc841ad1b74"
 dependencies = [
+ "async-mutex",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
  "hashbrown 0.9.1",
  "once_cell",
 ]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf857ae42d910aede5c5186e62684b0d7a597ce2fe3bd14448ab8f7ef439848c"
+dependencies = [
+ "async-mutex",
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -1672,6 +1696,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bs58",
+ "cached",
  "did-pkh",
  "hex",
  "ipfs-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 hex = "0.4"
 libipld = "0.12"
 tokio-stream = { version = "0.1", features = ["fs"] }
+cached = "0.23"
 
 [dev-dependencies]
 did-pkh = { git = "https://github.com/spruceid/ssi", branch = "main", package = "did-pkh" }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::orbit::{create_orbit, load_orbit, verify_oid, Orbit};
+use crate::orbit::{create_orbit, load_orbit, verify_oid, AuthTokens, Orbit, SimpleOrbit};
 use crate::tz::{TezosAuthorizationString, TezosBasicAuthorization};
 use anyhow::Result;
 use libipld::cid::Cid;
@@ -9,7 +9,7 @@ use rocket::{
 };
 use ssi::did::DIDURL;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Action {
     Put {
         orbit_id: Cid,
@@ -34,98 +34,221 @@ pub enum Action {
 }
 
 pub trait AuthorizationToken {
-    const HEADER_KEY: &'static str;
-    fn extract(auth_data: &str) -> Result<Self>;
+    // const HEADER_KEY: String;
+    fn extract(auth_data: &str) -> Result<Self>
+    where
+        Self: Sized;
     fn action(&self) -> &Action;
 }
 
 #[rocket::async_trait]
 pub trait AuthorizationPolicy {
     type Token: AuthorizationToken;
-    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a Action>;
+    async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<()>;
+}
+
+pub struct PutAuthWrapper(pub SimpleOrbit);
+pub struct GetAuthWrapper(pub SimpleOrbit);
+pub struct DelAuthWrapper(pub SimpleOrbit);
+pub struct CreateAuthWrapper(pub SimpleOrbit);
+pub struct ListAuthWrapper(pub SimpleOrbit);
+
+fn extract_info<T>(
+    req: &Request,
+) -> Result<(AuthTokens, config::Config), Outcome<T, anyhow::Error>> {
+    // TODO need to identify auth method from the headers
+    let auth_data = match req.headers().get_one("Authorization") {
+        Some(a) => a,
+        None => {
+            return Err(Outcome::Forward(()));
+        }
+    };
+    info_!("Headers: {}", auth_data);
+    let config = match req.rocket().state::<config::Config>() {
+        Some(c) => c,
+        None => {
+            return Err(Outcome::Failure((
+                Status::InternalServerError,
+                anyhow!("Could not retrieve config"),
+            )));
+        }
+    };
+    match TezosAuthorizationString::extract(auth_data) {
+        Ok(token) => Ok((AuthTokens::Tezos(token), config.clone())),
+        Err(e) => Err(Outcome::Failure((Status::Unauthorized, e))),
+    }
 }
 
 // TODO some APIs prefer to return 404 when the authentication fails to avoid leaking information about content
 #[rocket::async_trait]
-impl<'r, T> FromRequest<'r> for T
-where
-    T: Orbit,
-{
+impl<'r> FromRequest<'r> for PutAuthWrapper {
     type Error = anyhow::Error;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        // TODO need to identify auth method from the headers
-        let auth_data = match req.headers().get_one(TezosAuthorizationString::HEADER_KEY) {
-            Some(a) => a,
-            None => {
-                return Outcome::Forward(());
-            }
-        };
-        info_!("Headers: {}", auth_data);
-
-        let config = match req.rocket().state::<config::Config>() {
-            Some(c) => c,
-            None => {
-                return Outcome::Failure((
-                    Status::InternalServerError,
-                    anyhow!("Could not retrieve config"),
-                ))
-            }
-        };
-
-        // get token from headers
-        let token = match TezosAuthorizationString::extract(auth_data) {
-            Ok(t) => t,
-            Err(e) => return Outcome::Failure((Status::Unauthorized, e)),
+        let (token, config) = match extract_info(req) {
+            Ok(i) => i,
+            Err(o) => return o,
         };
         match token.action() {
-            // content actions have the same authz process
-            Action::Put { orbit_id, .. }
-            | Action::Get { orbit_id, .. }
-            | Action::List { orbit_id }
-            | Action::Del { orbit_id, .. } => {
-                let orbit = match load_orbit(config.database.path, orbit_id) {
-                    Some(o) => o,
-                    None => {
-                        return Outcome::Failure((Status::Unauthorized, anyhow!("No Orbit found")))
-                    }
+            Action::Put { orbit_id, .. } => {
+                let orbit = match load_orbit(*orbit_id, config.database.path.clone()).await {
+                    Ok(o) => o,
+                    // None => return Outcome::Failure((Status::NotFound, anyhow!("No Orbit found"))),
+                    Err(e) => return Outcome::Failure((Status::InternalServerError, e)),
                 };
-                match orbit.auth().authorize(&token).await {
-                    Ok(_) => Outcome::Success(orbit),
+                match orbit.auth().authorize(token).await {
+                    Ok(_) => Outcome::Success(Self(orbit)),
                     Err(e) => Outcome::Failure((Status::Unauthorized, e)),
                 }
             }
+            _ => Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("Token action not matching endpoint"),
+            )),
+        }
+    }
+}
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for GetAuthWrapper {
+    type Error = anyhow::Error;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let (token, config) = match extract_info(req) {
+            Ok(i) => i,
+            Err(o) => return o,
+        };
+        match token.action() {
+            Action::Get { orbit_id, .. } => {
+                let orbit = match load_orbit(*orbit_id, config.database.path.clone()).await {
+                    Ok(o) => o,
+                    // None => return Outcome::Failure((Status::NotFound, anyhow!("No Orbit found"))),
+                    Err(e) => return Outcome::Failure((Status::InternalServerError, e)),
+                };
+                match orbit.auth().authorize(token).await {
+                    Ok(_) => Outcome::Success(Self(orbit)),
+                    Err(e) => Outcome::Failure((Status::Unauthorized, e)),
+                }
+            }
+            _ => Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("Token action not matching endpoint"),
+            )),
+        }
+    }
+}
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for DelAuthWrapper {
+    type Error = anyhow::Error;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let (token, config) = match extract_info(req) {
+            Ok(i) => i,
+            Err(o) => return o,
+        };
+        match token.action() {
+            Action::Del { orbit_id, .. } => {
+                let orbit = match load_orbit(*orbit_id, config.database.path.clone()).await {
+                    Ok(o) => o,
+                    // None => return Outcome::Failure((Status::NotFound, anyhow!("No Orbit found"))),
+                    Err(e) => return Outcome::Failure((Status::InternalServerError, e)),
+                };
+                match orbit.auth().authorize(token).await {
+                    Ok(_) => Outcome::Success(Self(orbit)),
+                    Err(e) => Outcome::Failure((Status::Unauthorized, e)),
+                }
+            }
+            _ => Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("Token action not matching endpoint"),
+            )),
+        }
+    }
+}
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ListAuthWrapper {
+    type Error = anyhow::Error;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let (token, config) = match extract_info(req) {
+            Ok(i) => i,
+            Err(o) => return o,
+        };
+        match token.action() {
+            Action::List { orbit_id } => {
+                let orbit = match load_orbit(*orbit_id, config.database.path.clone()).await {
+                    Ok(o) => o,
+                    // None => return Outcome::Failure((Status::NotFound, anyhow!("No Orbit found"))),
+                    Err(e) => return Outcome::Failure((Status::InternalServerError, e)),
+                };
+                match orbit.auth().authorize(token).await {
+                    Ok(_) => Outcome::Success(Self(orbit)),
+                    Err(e) => Outcome::Failure((Status::Unauthorized, e)),
+                }
+            }
+            _ => Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("Token action not matching endpoint"),
+            )),
+        }
+    }
+}
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for CreateAuthWrapper {
+    type Error = anyhow::Error;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let (token, config) = match extract_info(req) {
+            Ok(i) => i,
+            Err(o) => return o,
+        };
+        // TODO remove clone
+        match token.clone().action() {
             // Create actions dont have an existing orbit to authorize against, it's a node policy
             // TODO have policy config, for now just be very permissive :shrug:
             Action::Create {
                 orbit_id,
                 parameters,
                 ..
-            } => match TezosBasicAuthorization.authorize(&token).await {
-                Ok(_) => {
-                    if let Err(e) = verify_oid(orbit_id, &token.pkh, parameters) {
-                        Outcome::Failure((Status::BadRequest, "Incorrect Orbit ID"))
+            } =>
+            // match AuthMethods.authorize(&token).await {
+                // TODO need to authorize?
+                // TODO don't create if it already exists
+                // Ok(_) => {
+            {
+                match token {
+                    AuthTokens::Tezos(token_tz) => {
+                    if let Err(_) = verify_oid(orbit_id, &token_tz.pkh, parameters) {
+                        return Outcome::Failure((
+                            Status::BadRequest,
+                            anyhow!("Incorrect Orbit ID"),
+                        ));
                     }
                     let vm = DIDURL {
-                        did: format!("did:pkh:tz:{}", &token.pkh),
+                        did: format!("did:pkh:tz:{}", &token_tz.pkh),
                         fragment: Some("TezosMethod2021".to_string()),
                         ..Default::default()
                     };
                     match create_orbit(
-                        orbit_id,
-                        config.database.path,
+                        *orbit_id,
+                        config.database.path.clone(),
                         TezosBasicAuthorization,
                         vec![vm],
-                        auth_data.as_bytes(),
+                        // auth_data.as_bytes(),
                     )
                     .await
                     {
-                        Ok(orbit) => Outcome::Success(orbit),
+                        Ok(orbit) => Outcome::Success(Self(orbit)),
                         Err(e) => Outcome::Failure((Status::InternalServerError, e)),
                     }
+                // }
+                // Err(e) => Outcome::Failure((Status::Unauthorized, e)),
                 }
-                Err(e) => Outcome::Failure((Status::Unauthorized, e)),
+            }
             },
+            _ => Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("Token action not matching endpoint"),
+            )),
         }
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,10 +1,13 @@
-use crate::orbit::{Orbit, OrbitCollection, Orbits, SimpleOrbit};
+use crate::config;
+use crate::orbit::{create_orbit, load_orbit, verify_oid, Orbit};
+use crate::tz::{TezosAuthorizationString, TezosBasicAuthorization};
 use anyhow::Result;
 use libipld::cid::Cid;
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},
 };
+use ssi::did::DIDURL;
 
 #[derive(Debug)]
 pub enum Action {
@@ -30,8 +33,7 @@ pub enum Action {
     },
 }
 
-pub trait AuthorizationToken: Sized {
-    type Policy: AuthorizationPolicy<Token = Self> + Send + Sync;
+pub trait AuthorizationToken {
     const HEADER_KEY: &'static str;
     fn extract(auth_data: &str) -> Result<Self>;
     fn action(&self) -> &Action;
@@ -39,69 +41,90 @@ pub trait AuthorizationToken: Sized {
 
 #[rocket::async_trait]
 pub trait AuthorizationPolicy {
-    type Token: AuthorizationToken<Policy = Self>;
+    type Token: AuthorizationToken;
     async fn authorize<'a>(&self, auth_token: &'a Self::Token) -> Result<&'a Action>;
 }
 
-pub struct AuthWrapper<T: AuthorizationToken>(pub T);
-
+// TODO some APIs prefer to return 404 when the authentication fails to avoid leaking information about content
 #[rocket::async_trait]
-impl<'r, T: 'static + AuthorizationToken + Send + Sync> FromRequest<'r> for AuthWrapper<T> {
+impl<'r, T> FromRequest<'r> for T
+where
+    T: Orbit,
+{
     type Error = anyhow::Error;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let auth_data = match req.headers().get_one(T::HEADER_KEY) {
+        // TODO need to identify auth method from the headers
+        let auth_data = match req.headers().get_one(TezosAuthorizationString::HEADER_KEY) {
             Some(a) => a,
             None => {
-                return Outcome::Failure((Status::Unauthorized, anyhow!("No Authorization Header")))
+                return Outcome::Forward(());
             }
         };
+        info_!("Headers: {}", auth_data);
 
-        // get token from headers
-        let token = match T::extract(auth_data) {
-            Ok(t) => t,
-            Err(e) => return Outcome::Failure((Status::Unauthorized, e)),
-        };
-        // get orbits state object
-        let orbits = match req.rocket().state::<Orbits<SimpleOrbit<T::Policy>>>() {
-            Some(orbits) => orbits,
+        let config = match req.rocket().state::<config::Config>() {
+            Some(c) => c,
             None => {
                 return Outcome::Failure((
-                    Status::Unauthorized,
-                    anyhow!("No authorization policy found"),
+                    Status::InternalServerError,
+                    anyhow!("Could not retrieve config"),
                 ))
             }
         };
 
+        // get token from headers
+        let token = match TezosAuthorizationString::extract(auth_data) {
+            Ok(t) => t,
+            Err(e) => return Outcome::Failure((Status::Unauthorized, e)),
+        };
         match token.action() {
             // content actions have the same authz process
             Action::Put { orbit_id, .. }
             | Action::Get { orbit_id, .. }
             | Action::List { orbit_id }
             | Action::Del { orbit_id, .. } => {
-                let read_orbits = orbits.orbits().await;
-                let orbit = match read_orbits.get(orbit_id) {
+                let orbit = match load_orbit(config.database.path, orbit_id) {
                     Some(o) => o,
                     None => {
-                        return Outcome::Failure((
-                            Status::Unauthorized,
-                            anyhow!("No authorization policy found"),
-                        ))
+                        return Outcome::Failure((Status::Unauthorized, anyhow!("No Orbit found")))
                     }
                 };
                 match orbit.auth().authorize(&token).await {
-                    Ok(_) => Outcome::Success(AuthWrapper(token)),
+                    Ok(_) => Outcome::Success(orbit),
                     Err(e) => Outcome::Failure((Status::Unauthorized, e)),
                 }
             }
             // Create actions dont have an existing orbit to authorize against, it's a node policy
             // TODO have policy config, for now just be very permissive :shrug:
-            Action::Create { .. } => match req.rocket().state::<T::Policy>() {
-                Some(auth) => match auth.authorize(&token).await {
-                    Ok(_) => Outcome::Success(AuthWrapper(token)),
-                    Err(e) => Outcome::Failure((Status::Unauthorized, e)),
-                },
-                None => Outcome::Success(AuthWrapper(token)),
+            Action::Create {
+                orbit_id,
+                parameters,
+                ..
+            } => match TezosBasicAuthorization.authorize(&token).await {
+                Ok(_) => {
+                    if let Err(e) = verify_oid(orbit_id, &token.pkh, parameters) {
+                        Outcome::Failure((Status::BadRequest, "Incorrect Orbit ID"))
+                    }
+                    let vm = DIDURL {
+                        did: format!("did:pkh:tz:{}", &token.pkh),
+                        fragment: Some("TezosMethod2021".to_string()),
+                        ..Default::default()
+                    };
+                    match create_orbit(
+                        orbit_id,
+                        config.database.path,
+                        TezosBasicAuthorization,
+                        vec![vm],
+                        auth_data.as_bytes(),
+                    )
+                    .await
+                    {
+                        Ok(orbit) => Outcome::Success(orbit),
+                        Err(e) => Outcome::Failure((Status::InternalServerError, e)),
+                    }
+                }
+                Err(e) => Outcome::Failure((Status::Unauthorized, e)),
             },
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Config {
     pub database: Database,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Database {
     pub path: PathBuf,
 }

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -129,7 +129,7 @@ pub async fn create_orbit(
     // TODO put back access logs
     // auth: &[u8],
 ) -> Result<SimpleOrbit> {
-    let dir = path.clone().join(oid.to_string_of_base(Base::Base58Btc)?);
+    let dir = path.join(oid.to_string_of_base(Base::Base58Btc)?);
 
     // fails if DIR exists, this is Create, not Open
     fs::create_dir(&dir)
@@ -163,6 +163,9 @@ pub async fn load_orbit(oid: Cid, path: PathBuf) -> Result<SimpleOrbit> {
     // }
     let mut cfg = Config::new(Some(dir.join("block_store")), 0);
     cfg.network.mdns = None;
+    cfg.network.gossipsub = None;
+    cfg.network.broadcast = None;
+    cfg.network.bitswap = None;
 
     let md: OrbitMetadata = serde_json::from_slice(&fs::read(dir.join("metadata")).await?)?;
 

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -129,7 +129,7 @@ pub async fn create_orbit(
     // TODO put back access logs
     // auth: &[u8],
 ) -> Result<SimpleOrbit> {
-    let dir = path.join(oid.to_string_of_base(Base::Base58Btc)?);
+    let dir = path.clone().join(oid.to_string_of_base(Base::Base58Btc)?);
 
     // fails if DIR exists, this is Create, not Open
     fs::create_dir(&dir)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,25 +6,22 @@ use rocket::{
     serde::json::Json,
     State,
 };
-use ssi::did::DIDURL;
 use std::path::PathBuf;
 
-use crate::auth::{Action, AuthWrapper, AuthorizationToken};
 use crate::cas::{CidWrap, ContentAddressedStorage};
 use crate::codec::{PutContent, SupportedCodecs};
-use crate::orbit::{create_orbit, verify_oid, Orbit, OrbitCollection, Orbits, SimpleOrbit};
-use crate::tz::{TezosAuthorizationString, TezosBasicAuthorization};
+use crate::config;
+use crate::orbit::{Orbit, SimpleOrbit};
 
-#[get("/<orbit_id>")]
+// TODO need to check for every relevant endpoint that the orbit ID in the URL matches the one in the auth token
+
+#[get("/<_orbit_id>")]
 pub async fn list_content(
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
-    _auth: Option<AuthWrapper<TezosAuthorizationString>>,
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
+    // Don't need it as we're using req.rocket().state ?
+    // config: &State<config::Config>,
 ) -> Result<Json<Vec<String>>, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     orbit
         .list()
         .await
@@ -41,17 +38,34 @@ pub async fn list_content(
         })
 }
 
-#[get("/<orbit_id>/<hash>")]
+#[get("/<_orbit_id>", rank = 2)]
+pub async fn list_content_no_auth(
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
+    config: &State<config::Config>,
+) -> Result<Json<Vec<String>>, (Status, &'static str)> {
+    orbit
+        .list()
+        .await
+        .map_err(|_| (Status::InternalServerError, "Failed to list Orbit contents"))
+        .and_then(|l| {
+            l.into_iter()
+                .map(|c| {
+                    orbit
+                        .make_uri(&c)
+                        .map_err(|_| (Status::InternalServerError, "Failed to serialize CID"))
+                })
+                .collect::<Result<Vec<String>, (Status, &'static str)>>()
+                .map(|v| Json(v))
+        })
+}
+
+#[get("/<_orbit_id>/<hash>")]
 pub async fn get_content(
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
     hash: CidWrap,
-    _auth: Option<AuthWrapper<TezosAuthorizationString>>,
 ) -> Result<Option<Vec<u8>>, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     match orbit.get(&hash.0).await {
         Ok(Some(content)) => Ok(Some(content.to_vec())),
         Ok(None) => Ok(None),
@@ -59,17 +73,26 @@ pub async fn get_content(
     }
 }
 
-#[post("/<orbit_id>", format = "multipart/form-data", data = "<batch>")]
+#[get("/<_orbit_id>/<hash>", rank = 2)]
+pub async fn get_content_no_auth(
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
+    hash: CidWrap,
+    config: &State<config::Config>,
+) -> Result<Option<Vec<u8>>, (Status, &'static str)> {
+    match orbit.get(&hash.0).await {
+        Ok(Some(content)) => Ok(Some(content.to_vec())),
+        Ok(None) => Ok(None),
+        Err(_) => Ok(None),
+    }
+}
+
+#[post("/<_orbit_id>", format = "multipart/form-data", data = "<batch>")]
 pub async fn batch_put_content(
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
     batch: Form<Vec<PutContent>>,
-    _auth: AuthWrapper<TezosAuthorizationString>,
 ) -> Result<String, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     let mut uris = Vec::<String>::new();
     for content in batch.into_inner().into_iter() {
         uris.push(
@@ -84,18 +107,13 @@ pub async fn batch_put_content(
     Ok(uris.join("\n"))
 }
 
-#[post("/<orbit_id>", data = "<data>", rank = 2)]
+#[post("/<_orbit_id>", data = "<data>", rank = 2)]
 pub async fn put_content(
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
     data: Data,
     codec: SupportedCodecs,
-    _auth: AuthWrapper<TezosAuthorizationString>,
 ) -> Result<String, (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     match orbit
         .put(
             &data
@@ -116,122 +134,53 @@ pub async fn put_content(
 
 #[post("/", format = "multipart/form-data", data = "<batch>")]
 pub async fn batch_put_create(
-    // TODO find a good way to not restrict all orbits to the same Type
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit: SimpleOrbit,
     batch: Form<Vec<PutContent>>,
-    auth: AuthWrapper<TezosAuthorizationString>,
 ) -> Result<String, (Status, &'static str)> {
-    match auth.0.action() {
-        Action::Create {
-            orbit_id,
-            parameters,
-            ..
-        } => {
-            verify_oid(orbit_id, &auth.0.pkh, parameters)
-                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
-
-            let vm = DIDURL {
-                did: format!("did:pkh:tz:{}", &auth.0.pkh),
-                fragment: Some("TezosMethod2021".to_string()),
-                ..Default::default()
-            };
-
-            let orbit = create_orbit(
-                *orbit_id,
-                &orbits.base_path,
-                TezosBasicAuthorization,
-                vec![vm],
-                auth.0.to_string().as_bytes(),
-            )
-            .await
-            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
-
-            let mut uris = Vec::<String>::new();
-            for content in batch.into_inner().into_iter() {
-                uris.push(
-                    orbit
-                        .put(&content.content, content.codec)
-                        .await
-                        .map_or("".into(), |cid| {
-                            orbit.make_uri(&cid).map_or("".into(), |s| s)
-                        }),
-                );
-            }
-            orbits.add(orbit).await;
-            Ok(uris.join("\n"))
-        }
-        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
+    let mut uris = Vec::<String>::new();
+    for content in batch.into_inner().into_iter() {
+        uris.push(
+            orbit
+                .put(&content.content, content.codec)
+                .await
+                .map_or("".into(), |cid| {
+                    orbit.make_uri(&cid).map_or("".into(), |s| s)
+                }),
+        );
     }
+    Ok(uris.join("\n"))
 }
 
 #[post("/", data = "<data>", rank = 2)]
 pub async fn put_create(
-    // TODO find a good way to not restrict all orbits to the same Type
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
+    orbit: SimpleOrbit,
     data: Data,
     codec: SupportedCodecs,
-    auth: AuthWrapper<TezosAuthorizationString>,
 ) -> Result<String, (Status, &'static str)> {
-    match auth.0.action() {
-        Action::Create {
-            orbit_id,
-            parameters,
-            ..
-        } => {
-            verify_oid(orbit_id, &auth.0.pkh, parameters)
-                .map_err(|_| (Status::BadRequest, "Incorrect Orbit ID"))?;
-
-            let vm = DIDURL {
-                did: format!("did:pkh:tz:{}", &auth.0.pkh),
-                fragment: Some("TezosMethod2021".to_string()),
-                ..Default::default()
-            };
-
-            let orbit = create_orbit(
-                *orbit_id,
-                &orbits.base_path,
-                TezosBasicAuthorization,
-                vec![vm],
-                auth.0.to_string().as_bytes(),
-            )
-            .await
-            .map_err(|_| (Status::Conflict, "Orbit Already Exists"))?;
-
-            let uri = orbit
-                .make_uri(
-                    &orbit
-                        .put(
-                            &data
-                                .open(1u8.megabytes())
-                                .into_bytes()
-                                .await
-                                .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
-                            codec,
-                        )
+    let uri = orbit
+        .make_uri(
+            &orbit
+                .put(
+                    &data
+                        .open(1u8.megabytes())
+                        .into_bytes()
                         .await
-                        .map_err(|_| (Status::InternalServerError, "Failed to store content"))?,
+                        .map_err(|_| (Status::BadRequest, "Failed to stream content"))?,
+                    codec,
                 )
-                .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?;
-
-            orbits.add(orbit).await;
-
-            Ok(uri)
-        }
-        _ => Err((Status::Unauthorized, "Incorrectly Authorized Action")),
-    }
+                .await
+                .map_err(|_| (Status::InternalServerError, "Failed to store content"))?,
+        )
+        .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?;
+    Ok(uri)
 }
 
-#[delete("/<orbit_id>/<hash>")]
+#[delete("/<_orbit_id>/<hash>")]
 pub async fn delete_content(
-    orbits: &State<Orbits<SimpleOrbit<TezosBasicAuthorization>>>,
-    orbit_id: CidWrap,
+    _orbit_id: CidWrap,
+    orbit: SimpleOrbit,
     hash: CidWrap,
-    _auth: AuthWrapper<TezosAuthorizationString>,
 ) -> Result<(), (Status, &'static str)> {
-    let orbits_read = orbits.orbits().await;
-    let orbit = orbits_read
-        .get(&orbit_id.0)
-        .ok_or_else(|| (Status::NotFound, "No Orbit Found"))?;
     Ok(orbit
         .delete(&hash.0)
         .await

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -8,78 +8,90 @@ use rocket::{
 };
 use std::path::PathBuf;
 
+use crate::auth::{
+    CreateAuthWrapper, DelAuthWrapper, GetAuthWrapper, ListAuthWrapper, PutAuthWrapper,
+};
 use crate::cas::{CidWrap, ContentAddressedStorage};
 use crate::codec::{PutContent, SupportedCodecs};
 use crate::config;
-use crate::orbit::{Orbit, SimpleOrbit};
+use crate::orbit::{load_orbit, Orbit, SimpleOrbit};
 
 // TODO need to check for every relevant endpoint that the orbit ID in the URL matches the one in the auth token
 
-#[get("/<_orbit_id>")]
-pub async fn list_content(
-    _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
-    // Don't need it as we're using req.rocket().state ?
-    // config: &State<config::Config>,
-) -> Result<Json<Vec<String>>, (Status, &'static str)> {
+async fn uri_listing(orbit: SimpleOrbit) -> Result<Json<Vec<String>>, (Status, String)> {
     orbit
         .list()
         .await
-        .map_err(|_| (Status::InternalServerError, "Failed to list Orbit contents"))
+        .map_err(|_| {
+            (
+                Status::InternalServerError,
+                "Failed to list Orbit contents".to_string(),
+            )
+        })
         .and_then(|l| {
             l.into_iter()
                 .map(|c| {
-                    orbit
-                        .make_uri(&c)
-                        .map_err(|_| (Status::InternalServerError, "Failed to serialize CID"))
+                    orbit.make_uri(&c).map_err(|_| {
+                        (
+                            Status::InternalServerError,
+                            "Failed to serialize CID".to_string(),
+                        )
+                    })
                 })
-                .collect::<Result<Vec<String>, (Status, &'static str)>>()
+                .collect::<Result<Vec<String>, (Status, String)>>()
                 .map(|v| Json(v))
         })
 }
 
-#[get("/<_orbit_id>", rank = 2)]
-pub async fn list_content_no_auth(
+#[get("/<_orbit_id>")]
+pub async fn list_content(
     _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit: ListAuthWrapper,
+    // Don't need it as we're using req.rocket().state ?
+    // config: &State<config::Config>,
+) -> Result<Json<Vec<String>>, (Status, String)> {
+    uri_listing(orbit.0).await
+}
+
+#[get("/<orbit_id>", rank = 2)]
+pub async fn list_content_no_auth(
+    orbit_id: CidWrap,
     config: &State<config::Config>,
-) -> Result<Json<Vec<String>>, (Status, &'static str)> {
-    orbit
-        .list()
-        .await
-        .map_err(|_| (Status::InternalServerError, "Failed to list Orbit contents"))
-        .and_then(|l| {
-            l.into_iter()
-                .map(|c| {
-                    orbit
-                        .make_uri(&c)
-                        .map_err(|_| (Status::InternalServerError, "Failed to serialize CID"))
-                })
-                .collect::<Result<Vec<String>, (Status, &'static str)>>()
-                .map(|v| Json(v))
-        })
+) -> Result<Json<Vec<String>>, (Status, String)> {
+    let orbit = match load_orbit(orbit_id.0, config.database.path.clone()).await {
+        // Ok(Some(o)) => o,
+        // Ok(None) => return Err((Status::NotFound, anyhow!("No Orbit found").to_string())),
+        Ok(o) => o,
+        Err(e) => return Err((Status::InternalServerError, e.to_string())),
+    };
+    uri_listing(orbit).await
 }
 
 #[get("/<_orbit_id>/<hash>")]
 pub async fn get_content(
     _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit: GetAuthWrapper,
     hash: CidWrap,
 ) -> Result<Option<Vec<u8>>, (Status, &'static str)> {
-    match orbit.get(&hash.0).await {
+    match orbit.0.get(&hash.0).await {
         Ok(Some(content)) => Ok(Some(content.to_vec())),
         Ok(None) => Ok(None),
         Err(_) => Ok(None),
     }
 }
 
-#[get("/<_orbit_id>/<hash>", rank = 2)]
+#[get("/<orbit_id>/<hash>", rank = 2)]
 pub async fn get_content_no_auth(
-    _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit_id: CidWrap,
     hash: CidWrap,
     config: &State<config::Config>,
-) -> Result<Option<Vec<u8>>, (Status, &'static str)> {
+) -> Result<Option<Vec<u8>>, (Status, String)> {
+    let orbit = match load_orbit(orbit_id.0, config.database.path.clone()).await {
+        // Ok(Some(o)) => o,
+        // Ok(None) => return Err((Status::NotFound, anyhow!("No Orbit found").to_string())),
+        Ok(o) => o,
+        Err(e) => return Err((Status::InternalServerError, e.to_string())),
+    };
     match orbit.get(&hash.0).await {
         Ok(Some(content)) => Ok(Some(content.to_vec())),
         Ok(None) => Ok(None),
@@ -90,17 +102,18 @@ pub async fn get_content_no_auth(
 #[post("/<_orbit_id>", format = "multipart/form-data", data = "<batch>")]
 pub async fn batch_put_content(
     _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit: PutAuthWrapper,
     batch: Form<Vec<PutContent>>,
 ) -> Result<String, (Status, &'static str)> {
     let mut uris = Vec::<String>::new();
     for content in batch.into_inner().into_iter() {
         uris.push(
             orbit
+                .0
                 .put(&content.content, content.codec)
                 .await
                 .map_or("".into(), |cid| {
-                    orbit.make_uri(&cid).map_or("".into(), |s| s)
+                    orbit.0.make_uri(&cid).map_or("".into(), |s| s)
                 }),
         );
     }
@@ -110,11 +123,12 @@ pub async fn batch_put_content(
 #[post("/<_orbit_id>", data = "<data>", rank = 2)]
 pub async fn put_content(
     _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit: PutAuthWrapper,
     data: Data,
     codec: SupportedCodecs,
 ) -> Result<String, (Status, &'static str)> {
     match orbit
+        .0
         .put(
             &data
                 .open(1u8.megabytes())
@@ -126,6 +140,7 @@ pub async fn put_content(
         .await
     {
         Ok(cid) => Ok(orbit
+            .0
             .make_uri(&cid)
             .map_err(|_| (Status::InternalServerError, "Failed to generate URI"))?),
         Err(_) => Err((Status::InternalServerError, "Failed to store content")),
@@ -134,17 +149,18 @@ pub async fn put_content(
 
 #[post("/", format = "multipart/form-data", data = "<batch>")]
 pub async fn batch_put_create(
-    orbit: SimpleOrbit,
+    orbit: CreateAuthWrapper,
     batch: Form<Vec<PutContent>>,
 ) -> Result<String, (Status, &'static str)> {
     let mut uris = Vec::<String>::new();
     for content in batch.into_inner().into_iter() {
         uris.push(
             orbit
+                .0
                 .put(&content.content, content.codec)
                 .await
                 .map_or("".into(), |cid| {
-                    orbit.make_uri(&cid).map_or("".into(), |s| s)
+                    orbit.0.make_uri(&cid).map_or("".into(), |s| s)
                 }),
         );
     }
@@ -153,13 +169,15 @@ pub async fn batch_put_create(
 
 #[post("/", data = "<data>", rank = 2)]
 pub async fn put_create(
-    orbit: SimpleOrbit,
+    orbit: CreateAuthWrapper,
     data: Data,
     codec: SupportedCodecs,
 ) -> Result<String, (Status, &'static str)> {
     let uri = orbit
+        .0
         .make_uri(
             &orbit
+                .0
                 .put(
                     &data
                         .open(1u8.megabytes())
@@ -178,10 +196,11 @@ pub async fn put_create(
 #[delete("/<_orbit_id>/<hash>")]
 pub async fn delete_content(
     _orbit_id: CidWrap,
-    orbit: SimpleOrbit,
+    orbit: DelAuthWrapper,
     hash: CidWrap,
 ) -> Result<(), (Status, &'static str)> {
     Ok(orbit
+        .0
         .delete(&hash.0)
         .await
         .map_err(|_| (Status::InternalServerError, "Failed to delete content"))?)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -59,9 +59,8 @@ pub async fn list_content_no_auth(
     config: &State<config::Config>,
 ) -> Result<Json<Vec<String>>, (Status, String)> {
     let orbit = match load_orbit(orbit_id.0, config.database.path.clone()).await {
-        // Ok(Some(o)) => o,
-        // Ok(None) => return Err((Status::NotFound, anyhow!("No Orbit found").to_string())),
-        Ok(o) => o,
+        Ok(Some(o)) => o,
+        Ok(None) => return Err((Status::NotFound, anyhow!("Orbit not found").to_string())),
         Err(e) => return Err((Status::InternalServerError, e.to_string())),
     };
     uri_listing(orbit).await
@@ -87,9 +86,8 @@ pub async fn get_content_no_auth(
     config: &State<config::Config>,
 ) -> Result<Option<Vec<u8>>, (Status, String)> {
     let orbit = match load_orbit(orbit_id.0, config.database.path.clone()).await {
-        // Ok(Some(o)) => o,
-        // Ok(None) => return Err((Status::NotFound, anyhow!("No Orbit found").to_string())),
-        Ok(o) => o,
+        Ok(Some(o)) => o,
+        Ok(None) => return Err((Status::NotFound, anyhow!("Orbit not found").to_string())),
         Err(e) => return Err((Status::InternalServerError, e.to_string())),
     };
     match orbit.get(&hash.0).await {

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -174,7 +174,6 @@ impl TezosAuthorizationString {
 
 impl AuthorizationToken for TezosAuthorizationString {
     const HEADER_KEY: &'static str = "Authorization";
-    type Policy = TezosBasicAuthorization;
 
     fn extract(auth_data: &str) -> Result<Self> {
         TezosAuthorizationString::from_str(auth_data)


### PR DESCRIPTION
Whilst adding caching to implement the on-demand loading of orbits, the current types/traits showed to be too interlinked for a more hierarchical/abstracted code structure.

This PR is a proposal and doesn't yet compile. Amongst the changes:
- the authentication goes through the orbit (one consequence is that we can directly give the orbit to the requests handlers); 
- I have removed cyclical dependent types and some inner types with the idea that most linked types only have one combination possible (e.g. a Tezos policy will only accept a Tezos token) meaning we will probably only need hierarchies of enums; and
- I added caching using `cached`.