### PR TITLE
add a config entry for allowing public GET requests

### DIFF
--- a/kepler.toml
+++ b/kepler.toml
@@ -1,6 +1,8 @@
 [global]
 # log_level = "normal"
 # port = 8000
+## allow unauthorized GET requests
+# public_get = false
 
 ## Example of nest config variable: KEPLER_DATABASE_PATH
 [global.database]

--- a/kepler.toml
+++ b/kepler.toml
@@ -9,6 +9,8 @@
 ## Directory where the database will be stored.
 # path = "/tmp"
 
+[global.orbits]
+## allow unauthorized get requests
+# public = true
 ## Orbit allow list api endpoint
-[global.orbit_allow_list]
-# api = "http://localhost:10000"
+# allowlist = "http://localhost:10000"

--- a/kepler.toml
+++ b/kepler.toml
@@ -1,8 +1,6 @@
 [global]
 # log_level = "normal"
 # port = 8000
-## allow unauthorized GET requests
-# public_get = false
 
 ## Example of nest config variable: KEPLER_DATABASE_PATH
 [global.database]

--- a/src/allow_list.rs
+++ b/src/allow_list.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use ipfs_embed::Cid;
 use libipld::multibase::Base;
-use reqwest::{get, StatusCode};
+use reqwest::get;
 use serde::{Deserialize, Serialize};
 use ssi::did::DIDURL;
 
@@ -11,11 +11,18 @@ pub trait OrbitAllowList {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(from = "String", into = "String")]
 pub struct OrbitAllowListService(pub String);
 
-impl Default for OrbitAllowListService {
-    fn default() -> Self {
-        Self("http://localhost:11000".into())
+impl From<String> for OrbitAllowListService {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<OrbitAllowListService> for String {
+    fn from(oals: OrbitAllowListService) -> Self {
+        oals.0
     }
 }
 

--- a/src/allow_list.rs
+++ b/src/allow_list.rs
@@ -11,15 +11,11 @@ pub trait OrbitAllowList {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct OrbitAllowListService {
-    pub api: String,
-}
+pub struct OrbitAllowListService(pub String);
 
 impl Default for OrbitAllowListService {
     fn default() -> Self {
-        Self {
-            api: "http://localhost:11000".into(),
-        }
+        Self("http://localhost:11000".into())
     }
 }
 
@@ -27,7 +23,7 @@ impl Default for OrbitAllowListService {
 impl OrbitAllowList for OrbitAllowListService {
     async fn is_allowed(&self, oid: &Cid) -> Result<Vec<DIDURL>> {
         Ok(
-            get([self.api.as_str(), &oid.to_string_of_base(Base::Base58Btc)?].join("/"))
+            get([self.0.as_str(), &oid.to_string_of_base(Base::Base58Btc)?].join("/"))
                 .await?
                 .error_for_status()?
                 .json::<Vec<DIDURL>>()

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct OrbitsConfig {
+    #[serde(default)]
     pub public: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowlist: Option<OrbitAllowListService>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,14 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Config {
     pub database: Database,
+    pub orbits: OrbitsConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct OrbitsConfig {
+    pub public: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub orbit_allow_list: Option<OrbitAllowListService>,
-    pub public_get: bool,
+    pub allowlist: Option<OrbitAllowListService>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub database: Database,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub orbit_allow_list: Option<OrbitAllowListService>,
+    pub public_get: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,22 +35,24 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         ));
     }
 
+    let mut routes = routes![
+        list_content,
+        get_content,
+        put_content,
+        batch_put_content,
+        delete_content,
+        open_orbit_allowlist,
+        open_orbit_authz,
+        cors
+    ];
+
+    if kepler_config.public_get {
+        let mut no_auth = routes![get_content_no_auth, list_content_no_auth];
+        routes.append(&mut no_auth);
+    };
+
     Ok(rocket::custom(config)
-        .mount(
-            "/",
-            routes![
-                list_content,
-                list_content_no_auth,
-                get_content,
-                get_content_no_auth,
-                put_content,
-                batch_put_content,
-                delete_content,
-                open_orbit_allowlist,
-                open_orbit_authz,
-                cors
-            ],
-        )
+        .mount("/", routes)
         .attach(AdHoc::config::<config::Config>())
         .attach(AdHoc::on_response("CORS", |_, resp| {
             Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         cors
     ];
 
-    if kepler_config.public_get {
+    if kepler_config.orbits.public {
         let mut no_auth = routes![get_content_no_auth, list_content_no_auth];
         routes.append(&mut no_auth);
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,6 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     }
 
     let mut routes = routes![
-        list_content,
-        get_content,
         put_content,
         batch_put_content,
         delete_content,
@@ -49,7 +47,10 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     if kepler_config.public_get {
         let mut no_auth = routes![get_content_no_auth, list_content_no_auth];
         routes.append(&mut no_auth);
-    };
+    } else {
+        let mut auth = routes![get_content, list_content];
+        routes.append(&mut auth);
+    }
 
     Ok(rocket::custom(config)
         .mount("/", routes)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -186,7 +186,7 @@ pub async fn open_orbit_allowlist(
     // no auth token, use allowlist
     match (
         verify_oid(&orbit_id.0, params_str),
-        config.orbit_allow_list.as_ref(),
+        config.orbits.allowlist.as_ref(),
     ) {
         (_, None) => Err((Status::InternalServerError, "Allowlist Not Configured")),
         (Ok(_), Some(list)) => match list.is_allowed(&orbit_id.0).await {


### PR DESCRIPTION
Set `public_get = true` in `kepler.toml` or set env var `KEPLER_PUBLIC_GET=true` to serve GET requests without authorization.