### PR TITLE
Ceramic orbit manifest

### DIFF
--- a/kepler.toml
+++ b/kepler.toml
@@ -16,3 +16,5 @@
 [global.apis]
 ## API for tzkt
 # tzkt = "http://localhost:5000"
+## API for ceramic
+# ceramic = "http://localhost:7007"

--- a/src/ceramic_orbit.rs
+++ b/src/ceramic_orbit.rs
@@ -1,0 +1,96 @@
+use crate::orbit::OrbitMetadata;
+use anyhow::Result;
+use ipfs_embed::{Multiaddr, PeerId};
+use libipld::cid::Cid;
+use reqwest;
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
+use ssi::did::DIDURL;
+use std::collections::HashMap as Map;
+
+#[serde_as]
+#[derive(Deserialize)]
+struct TileContent {
+    #[serde_as(as = "Map<DisplayFromStr, _>")]
+    pub hosts: Map<PeerId, Vec<Multiaddr>>,
+}
+
+#[derive(Deserialize)]
+struct TileMetadata {
+    pub controllers: Vec<DIDURL>,
+}
+
+#[derive(Deserialize)]
+struct TileState {
+    pub content: TileContent,
+    pub metadata: TileMetadata,
+}
+
+#[derive(Deserialize)]
+struct StateResponseBody {
+    pub state: TileState,
+}
+
+async fn get_tile_state(ceramic_api: &str, stream_id: &str) -> Result<TileState> {
+    Ok(
+        reqwest::get(format!("{}/api/v0/streams/{}", ceramic_api, stream_id))
+            .await?
+            .json::<StateResponseBody>()
+            .await?
+            .state,
+    )
+}
+
+fn didkey_to_did_vm(did: DIDURL) -> DIDURL {
+    DIDURL {
+        fragment: did
+            .fragment
+            .or(did.did.strip_prefix("did:key:").map(String::from)),
+        ..did
+    }
+}
+
+pub async fn get_orbit_state(ceramic_api: &str, stream_id: &str, id: Cid) -> Result<OrbitMetadata> {
+    let state = get_tile_state(ceramic_api, stream_id).await?;
+
+    Ok(OrbitMetadata {
+        id,
+        controllers: state
+            .metadata
+            .controllers
+            .into_iter()
+            .map(|did| didkey_to_did_vm(did))
+            .collect(),
+        hosts: state.content.hosts,
+        read_delegators: vec![],
+        write_delegators: vec![],
+        revocations: vec![],
+    })
+}
+
+pub async fn params_to_ceramic_orbit(
+    oid: Cid,
+    params: &Map<String, String>,
+    ceramic_api: &str,
+) -> Result<OrbitMetadata> {
+    match params.get("stream") {
+        // try read orbit state from stream
+        Some(v) => Ok(get_orbit_state(ceramic_api, v, oid).await?),
+        _ => Err(anyhow!("Missing stream ID")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    async fn test() -> Result<()> {
+        let stream_id = "kjzl6cwe1jw14966o3mfhkccx6rmqjlnx9g0o41hehcpbt7pgx5xc96nub5qxj6";
+        let oid = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi".parse()?;
+        let st = get_orbit_state("http://localhost:7007", stream_id, oid).await?;
+        println!("{:#?}", st);
+        assert!(false);
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ impl Default for Database {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ExternalApis {
     pub tzkt: Option<String>,
+    pub ceramic: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use rocket::{fairing::AdHoc, figment::Figment, http::Header, tokio::fs, Build, R
 pub mod allow_list;
 pub mod auth;
 pub mod cas;
+pub mod ceramic_orbit;
 pub mod codec;
 pub mod config;
 pub mod ipfs;

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -1,6 +1,7 @@
 use crate::{
     auth::{Action, AuthorizationPolicy, AuthorizationToken},
     cas::ContentAddressedStorage,
+    ceramic_orbit::params_to_ceramic_orbit,
     codec::SupportedCodecs,
     config::ExternalApis,
     tz::TezosAuthorizationString,
@@ -138,6 +139,12 @@ pub async fn create_orbit(
                 tzkt: Some(api), ..
             },
         ) => params_to_tz_orbit(oid, &params, &api).await?,
+        (
+            "ceramic",
+            ExternalApis {
+                ceramic: Some(api), ..
+            },
+        ) => params_to_ceramic_orbit(oid, &params, &api).await?,
         _ => OrbitMetadata {
             id: oid.clone(),
             controllers: controllers,

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -33,7 +33,7 @@ use ssi::did::DIDURL;
 use std::{collections::HashMap as Map, convert::TryFrom, path::PathBuf, sync::RwLock};
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct OrbitMetadata {
     // NOTE This will always serialize in b58check
     #[serde_as(as = "DisplayFromStr")]


### PR DESCRIPTION
Implements support for Orbit Manifests implemented as Ceramic Tiles. Such Tiles are only expected to have a `hosts` key which contains the `PeerId` to `Multiaddr[]` mapping required for hosts to discover eachother. Controllers of the Tile are also the controllers of the Orbit. Note that Ceramic by default uses `did:idx` for controllers, so convenient integration will require:
- `did:idx` support in `didkit`
- and/or `did:pkh` support in Ceramic

This PR builds on PR #59 