### PR TITLE
fix/period-prefixed-uploads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,18 +18,18 @@ pub mod orbit;
 pub mod relay;
 pub mod routes;
 pub mod s3;
-pub mod s3_routes;
 pub mod tz;
 pub mod tz_orbit;
 pub mod zcap;
 
 use ipfs_embed::{generate_keypair, Keypair, PeerId, ToLibp2p};
 use relay::RelayNode;
-use routes::{
+use routes::core::{
     batch_put_content, cors, delete_content, get_content, get_content_no_auth, list_content,
     list_content_no_auth, open_host_key, open_orbit_allowlist, open_orbit_authz, put_content,
     relay_addr,
 };
+use routes::s3 as s3_routes;
 use std::{collections::HashMap, sync::RwLock};
 
 pub fn tracing_try_init() {
@@ -78,6 +78,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
             get_content_no_auth,
             list_content_no_auth,
             s3_routes::get_content_no_auth,
+            s3_routes::get_metadata_no_auth,
             s3_routes::list_content_no_auth,
         ];
         routes.append(&mut no_auth);
@@ -86,6 +87,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
             get_content,
             list_content,
             s3_routes::get_content,
+            s3_routes::get_metadata,
             s3_routes::list_content,
         ];
         routes.append(&mut auth);

--- a/src/routes/core.rs
+++ b/src/routes/core.rs
@@ -7,7 +7,7 @@ use rocket::{
     serde::json::Json,
     State,
 };
-use std::{collections::HashMap, path::PathBuf, sync::RwLock};
+use std::{collections::HashMap, sync::RwLock};
 
 use crate::allow_list::OrbitAllowList;
 use crate::auth::{
@@ -18,6 +18,7 @@ use crate::codec::{PutContent, SupportedCodecs};
 use crate::config;
 use crate::orbit::{create_orbit, get_metadata, load_orbit, Orbit};
 use crate::relay::RelayNode;
+use crate::routes::DotPathBuf;
 
 // TODO need to check for every relevant endpoint that the orbit ID in the URL matches the one in the auth token
 async fn uri_listing(orbit: Orbit) -> Result<Json<Vec<String>>, (Status, String)> {
@@ -234,7 +235,7 @@ pub async fn open_orbit_allowlist(
 }
 
 #[options("/<_s..>")]
-pub async fn cors(_s: PathBuf) {}
+pub async fn cors(_s: DotPathBuf) {}
 
 #[get("/peer/relay")]
 pub fn relay_addr(relay: &State<RelayNode>) -> String {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,18 @@
+pub mod core;
+pub mod s3;
+
+use std::path::PathBuf;
+
+use rocket::{
+    http::uri::{error::PathError, fmt::Path, Segments},
+    request::FromSegments,
+};
+
+pub struct DotPathBuf(PathBuf);
+
+impl<'r> FromSegments<'r> for DotPathBuf {
+    type Error = PathError;
+    fn from_segments(segments: Segments<'r, Path>) -> Result<Self, Self::Error> {
+        segments.to_path_buf(true).map(DotPathBuf)
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod core;
 pub mod s3;
 
+use std::ops::Deref;
 use std::path::PathBuf;
 
 use rocket::{
@@ -14,5 +15,12 @@ impl<'r> FromSegments<'r> for DotPathBuf {
     type Error = PathError;
     fn from_segments(segments: Segments<'r, Path>) -> Result<Self, Self::Error> {
         segments.to_path_buf(true).map(DotPathBuf)
+    }
+}
+
+impl Deref for DotPathBuf {
+    type Target = PathBuf;
+    fn deref(&self) -> &PathBuf {
+        &self.0
     }
 }

--- a/src/routes/s3.rs
+++ b/src/routes/s3.rs
@@ -14,8 +14,9 @@ use crate::cas::CidWrap;
 use crate::config;
 use crate::orbit::load_orbit;
 use crate::relay::RelayNode;
+use crate::routes::DotPathBuf;
 use crate::s3::{IpfsReadStream, ObjectBuilder};
-use std::{collections::BTreeMap, path::PathBuf};
+use std::collections::BTreeMap;
 
 pub struct Metadata(pub BTreeMap<String, String>);
 
@@ -116,9 +117,9 @@ pub async fn list_content(
 pub async fn get_metadata(
     _orbit_id: CidWrap,
     orbit: GetAuthWrapper,
-    key: PathBuf,
+    key: DotPathBuf,
 ) -> Result<Option<Metadata>, (Status, String)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -132,11 +133,11 @@ pub async fn get_metadata(
 #[head("/<orbit_id>/s3/<key..>")]
 pub async fn get_metadata_no_auth(
     orbit_id: CidWrap,
-    key: PathBuf,
+    key: DotPathBuf,
     config: &State<config::Config>,
     relay: &State<RelayNode>,
 ) -> Result<Option<Metadata>, (Status, String)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -162,9 +163,9 @@ pub async fn get_metadata_no_auth(
 pub async fn get_content(
     _orbit_id: CidWrap,
     orbit: GetAuthWrapper,
-    key: PathBuf,
+    key: DotPathBuf,
 ) -> Result<Option<S3Response>, (Status, String)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -177,11 +178,11 @@ pub async fn get_content(
 #[get("/<orbit_id>/s3/<key..>", rank = 8)]
 pub async fn get_content_no_auth(
     orbit_id: CidWrap,
-    key: PathBuf,
+    key: DotPathBuf,
     config: &State<config::Config>,
     relay: &State<RelayNode>,
 ) -> Result<Option<S3Response>, (Status, String)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -207,11 +208,11 @@ pub async fn get_content_no_auth(
 pub async fn put_content(
     _orbit_id: CidWrap,
     orbit: PutAuthWrapper,
-    key: PathBuf,
+    key: DotPathBuf,
     md: Metadata,
     data: Data<'_>,
 ) -> Result<(), (Status, String)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -236,9 +237,9 @@ pub async fn put_content(
 pub async fn delete_content(
     _orbit_id: CidWrap,
     orbit: DelAuthWrapper,
-    key: PathBuf,
+    key: DotPathBuf,
 ) -> Result<(), (Status, &'static str)> {
-    let k = match key.to_str() {
+    let k = match key.0.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed")),
     };

--- a/src/routes/s3.rs
+++ b/src/routes/s3.rs
@@ -119,7 +119,7 @@ pub async fn get_metadata(
     orbit: GetAuthWrapper,
     key: DotPathBuf,
 ) -> Result<Option<Metadata>, (Status, String)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -137,7 +137,7 @@ pub async fn get_metadata_no_auth(
     config: &State<config::Config>,
     relay: &State<RelayNode>,
 ) -> Result<Option<Metadata>, (Status, String)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -165,7 +165,7 @@ pub async fn get_content(
     orbit: GetAuthWrapper,
     key: DotPathBuf,
 ) -> Result<Option<S3Response>, (Status, String)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -182,7 +182,7 @@ pub async fn get_content_no_auth(
     config: &State<config::Config>,
     relay: &State<RelayNode>,
 ) -> Result<Option<S3Response>, (Status, String)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -212,7 +212,7 @@ pub async fn put_content(
     md: Metadata,
     data: Data<'_>,
 ) -> Result<(), (Status, String)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
@@ -239,7 +239,7 @@ pub async fn delete_content(
     orbit: DelAuthWrapper,
     key: DotPathBuf,
 ) -> Result<(), (Status, &'static str)> {
-    let k = match key.0.to_str() {
+    let k = match key.to_str() {
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed")),
     };


### PR DESCRIPTION
Problem: when trying to upload period-prefixed files into kepler, requests 404. On Kepler we see:
```
Dec 08 11:27:29.989 ERROR _: No matching routes for OPTIONS /<orbit_id>/s3/.gitignore.
```

Cause: Rocket code for parsing to a PathBuf is failing when a part begins with a period:

```
GET /hello/world/.vimrc:
   >> Matched: (echo) GET /<_a..>
   >> `_a: PathBuf` param guard parsed forwarding with error BadStart('.')
   >> Outcome: Forward
   >> No matching routes for GET /hello/world/.vimrc.
```

Solution: Create a new type wrapper for PathBuf which implements FromParts in the same way, except it allows dotfiles.