### PR TITLE
fix/add-clippy-and-fmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,17 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Kepler repository
+      uses: actions/checkout@v2
+      with:
+        path: kepler
+
+    - name: Clippy
+      run: RUSTFLAGS="-Dwarnings" cargo clippy
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,14 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Kepler repository
+      uses: actions/checkout@v2
+      with:
+        path: kepler
+
+    - name: Fmt
+      run: cargo fmt -- --check

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -45,10 +45,7 @@ async fn extract_info<T>(
     req: &Request<'_>,
 ) -> Result<(Vec<u8>, AuthTokens, config::Config, (PeerId, Multiaddr)), Outcome<T, anyhow::Error>> {
     // TODO need to identify auth method from the headers
-    let auth_data = match req.headers().get_one("Authorization") {
-        Some(a) => a,
-        None => "",
-    };
+    let auth_data = req.headers().get_one("Authorization").unwrap_or("");
     let config = match req.rocket().state::<config::Config>() {
         Some(c) => c,
         None => {
@@ -59,7 +56,7 @@ async fn extract_info<T>(
         }
     };
     let relay = match req.rocket().state::<RelayNode>() {
-        Some(r) => (r.id.clone(), r.internal()),
+        Some(r) => (r.id, r.internal()),
         _ => {
             return Err(Outcome::Failure((
                 Status::InternalServerError,

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -45,7 +45,7 @@ impl ContentAddressedStorage for Ipfs {
     async fn list(&self) -> Result<Vec<Cid>, Self::Error> {
         // return a list of all CIDs which are aliased/pinned
         self.iter().map(|i| {
-            i.filter(|c| self.reverse_alias(&c).map(|o| o.is_some()).unwrap_or(false))
+            i.filter(|c| self.reverse_alias(c).map(|o| o.is_some()).unwrap_or(false))
                 .collect()
         })
     }

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,6 +1,6 @@
 use super::cas::ContentAddressedStorage;
 use super::codec::SupportedCodecs;
-use ipfs_embed::{Ipfs as OIpfs, DefaultParams};
+use ipfs_embed::{DefaultParams, Ipfs as OIpfs};
 use libipld::{
     block::Block as OBlock,
     cid::{multihash::Code, Cid},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use kepler::{app, config, tracing_try_init};
-use rocket::figment::providers::{Format, Serialized, Toml, Env};
+use rocket::figment::providers::{Env, Format, Serialized, Toml};
 
 #[rocket::main]
 async fn main() {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -183,7 +183,10 @@ pub async fn delete_content(
 }
 
 #[post("/<orbit_id>")]
-pub async fn open_orbit_authz(orbit_id: CidWrap, authz: CreateAuthWrapper) -> Result<String, (Status, &'static str)> {
+pub async fn open_orbit_authz(
+    orbit_id: CidWrap,
+    authz: CreateAuthWrapper,
+) -> Result<String, (Status, &'static str)> {
     // create auth success, return OK
     if &orbit_id.0 == authz.0.id() {
         Ok(authz.0.id().to_string())

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -41,7 +41,7 @@ async fn uri_listing(orbit: Orbit) -> Result<Json<Vec<String>>, (Status, String)
                     })
                 })
                 .collect::<Result<Vec<String>, (Status, String)>>()
-                .map(|v| Json(v))
+                .map(Json)
         })
 }
 
@@ -234,9 +234,7 @@ pub async fn open_orbit_allowlist(
 }
 
 #[options("/<_s..>")]
-pub async fn cors(_s: PathBuf) -> () {
-    ()
-}
+pub async fn cors(_s: PathBuf) {}
 
 #[get("/peer/relay")]
 pub fn relay_addr(relay: &State<RelayNode>) -> String {

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -64,7 +64,7 @@ mod vec_cid_bin {
     use libipld::cid::Cid;
     use serde::{de::Error as DeError, ser::SerializeSeq, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(vec: &Vec<Cid>, ser: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(vec: &[Cid], ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -87,11 +87,11 @@ mod vec_cid_bin {
 }
 
 fn to_block<T: Encode<DagCborCodec>>(data: &T) -> Result<Block> {
-    Ok(Block::encode(DagCborCodec, Code::Blake3_256, data)?)
+    Block::encode(DagCborCodec, Code::Blake3_256, data)
 }
 
 fn to_block_raw<T: AsRef<[u8]>>(data: &T) -> Result<Block> {
-    Ok(Block::encode(RawCodec, Code::Blake3_256, data.as_ref())?)
+    Block::encode(RawCodec, Code::Blake3_256, data.as_ref())
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -10,7 +10,7 @@ mod store;
 
 use super::ipfs::{Block, Ipfs};
 
-pub use entries::{Object, ObjectBuilder, IpfsWriteStream, IpfsReadStream};
+pub use entries::{IpfsReadStream, IpfsWriteStream, Object, ObjectBuilder};
 pub use store::Store;
 
 type TaskHandle = tokio::task::JoinHandle<()>;
@@ -184,8 +184,12 @@ mod test {
         let s3_obj_2 = ObjectBuilder::new(key2.as_bytes().to_vec(), md.clone());
 
         let rm: Vec<(Vec<u8>, Option<(u64, Cid)>)> = vec![];
-        alice_service.write(vec![(s3_obj_1, json.as_bytes())], rm.clone()).await?;
-        bob_service.write(vec![(s3_obj_2, json.as_bytes())], rm).await?;
+        alice_service
+            .write(vec![(s3_obj_1, json.as_bytes())], rm.clone())
+            .await?;
+        bob_service
+            .write(vec![(s3_obj_2, json.as_bytes())], rm)
+            .await?;
 
         {
             // ensure only alice has s3_obj_1

--- a/src/s3_routes.rs
+++ b/src/s3_routes.rs
@@ -199,7 +199,7 @@ pub async fn get_content_no_auth(
 
     match orbit.service.read(k) {
         Ok(Some((md, r))) => Ok(Some(S3Response::new(Metadata(md), r))),
-        _ => return Ok(None),
+        _ => Ok(None),
     }
 }
 
@@ -215,7 +215,7 @@ pub async fn put_content(
         Some(k) => k,
         _ => return Err((Status::BadRequest, "Key parsing failed".into())),
     };
-    let rm: Vec<(Vec<u8>, Option<(u64, Cid)>)> = vec![];
+    let rm: [(Vec<u8>, _); 0] = [];
 
     orbit
         .0
@@ -240,7 +240,7 @@ pub async fn delete_content(
 ) -> Result<(), (Status, &'static str)> {
     let k = match key.to_str() {
         Some(k) => k,
-        _ => return Err((Status::BadRequest, "Key parsing failed".into())),
+        _ => return Err((Status::BadRequest, "Key parsing failed")),
     };
     let add: Vec<(&[u8], Cid)> = vec![];
     Ok(orbit

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -138,7 +138,7 @@ fn serialize_action(action: &Action) -> Result<String> {
         Action::Create {
             content,
             parameters,
-        } => Ok(["CREATE", &parameters, &content.join(" ")].join(" ")),
+        } => Ok(["CREATE", parameters, &content.join(" ")].join(" ")),
     }
 }
 

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -100,7 +100,7 @@ impl AuthorizationPolicy<ZCAPTokens> for OrbitMetadata {
             .as_ref()
             .and_then(|proof| proof.verification_method.as_ref())
             .ok_or_else(|| anyhow!("Missing delegation verification method"))
-            .and_then(|s| DIDURL::from_str(&s).map_err(|e| e.into()))?;
+            .and_then(|s| DIDURL::from_str(s).map_err(|e| e.into()))?;
         let res = match &auth_token.delegation {
             Some(d) => {
                 let delegator_vm = d
@@ -108,7 +108,7 @@ impl AuthorizationPolicy<ZCAPTokens> for OrbitMetadata {
                     .as_ref()
                     .and_then(|proof| proof.verification_method.as_ref())
                     .ok_or_else(|| anyhow!("Missing delegation verification method"))
-                    .and_then(|s| DIDURL::from_str(&s).map_err(|e| e.into()))?;
+                    .and_then(|s| DIDURL::from_str(s).map_err(|e| e.into()))?;
                 match auth_token.invocation.property_set.capability_action {
                     Action::List | Action::Get(_) => {
                         if !self.read_delegators.contains(&delegator_vm)
@@ -155,7 +155,7 @@ impl AuthorizationPolicy<ZCAPTokens> for OrbitMetadata {
                     .await;
                 let mut res2 = auth_token
                     .invocation
-                    .verify(Default::default(), DID_METHODS.to_resolver(), &d)
+                    .verify(Default::default(), DID_METHODS.to_resolver(), d)
                     .await;
                 res.append(&mut res2);
                 res


### PR DESCRIPTION
I think the only controversial lint clippy suggested was boxing the ZCAP:
```
warning: large size difference between variants
  --> src/orbit.rs:79:5
   |
79 |     ZCAP(ZCAPTokens),
   |     ^^^^^^^^^^^^^^^^ this variant is 1112 bytes
   |
   = note: `#[warn(clippy::large_enum_variant)]` on by default
note: and the second-largest variant is 272 bytes:
203     }
  --> src/orbit.rs:78:5
   |
78 |     Tezos(TezosAuthorizationString),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Let me know if you want me to revert that and add an ignore directive.