### PR TITLE
Sign In With Ethereum support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+
+[[package]]
 name = "derive_builder"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7ecda243cd92126e3045aa2d18c23a4277e8ffb890b995a65dd9c94da8f8fe7"
 dependencies = [
  "async-trait",
- "k256",
+ "k256 0.8.1",
  "multibase 0.8.0",
  "p256",
  "serde_json",
@@ -1348,8 +1366,20 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
 dependencies = [
- "der",
- "elliptic-curve",
+ "der 0.3.5",
+ "elliptic-curve 0.9.12",
+ "hmac 0.11.0",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+dependencies = [
+ "der 0.4.5",
+ "elliptic-curve 0.10.6",
  "hmac 0.11.0",
  "signature",
 ]
@@ -1390,10 +1420,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
  "bitvec 0.20.4",
- "ff",
+ "ff 0.9.0",
  "generic-array 0.14.4",
- "group",
+ "group 0.9.0",
  "pkcs8",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+dependencies = [
+ "crypto-bigint",
+ "ff 0.10.1",
+ "generic-array 0.14.4",
+ "group 0.10.0",
  "rand_core 0.6.3",
  "subtle 2.4.1",
  "zeroize",
@@ -1492,6 +1537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
  "bitvec 0.20.4",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+]
+
+[[package]]
+name = "ff"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
  "rand_core 0.6.3",
  "subtle 2.4.1",
 ]
@@ -1850,7 +1905,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
 dependencies = [
- "ff",
+ "ff 0.9.0",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+]
+
+[[package]]
+name = "group"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+dependencies = [
+ "ff 0.10.1",
  "rand_core 0.6.3",
  "subtle 2.4.1",
 ]
@@ -2215,6 +2281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326cf970601ca3f0a79e1727b606009d75a8104a0489d146982828141b2c044"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,9 +2381,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3e8e491ed22bc161583a1c77e42313672c483eba6bd9d7afec0f1131d0b9ce"
 dependencies = [
  "cfg-if 1.0.0",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.11.1",
+ "elliptic-curve 0.9.12",
  "sha2 0.9.8",
+ "sha3",
+]
+
+[[package]]
+name = "k256"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa 0.12.4",
+ "elliptic-curve 0.10.6",
  "sha3",
 ]
 
@@ -2350,6 +2437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "siwe",
  "sled",
  "ssi",
  "tempdir",
@@ -3524,8 +3612,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.11.1",
+ "elliptic-curve 0.9.12",
  "sha2 0.9.8",
 ]
 
@@ -3733,7 +3821,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110"
 dependencies = [
- "der",
+ "der 0.3.5",
  "spki",
 ]
 
@@ -4754,6 +4842,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
+ "hex",
  "rustversion",
  "serde",
  "serde_with_macros",
@@ -4880,6 +4969,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "siwe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524f2d6eb394f768b22b3dfd317f1bfcab159fa6ac4268026354384643680f3a"
+dependencies = [
+ "chrono",
+ "hex",
+ "iri-string",
+ "k256 0.9.6",
+ "sha3",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4980,7 +5084,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
 dependencies = [
- "der",
+ "der 0.3.5",
 ]
 
 [[package]]
@@ -5011,7 +5115,7 @@ dependencies = [
  "combination",
  "derive_builder",
  "digest 0.9.0",
- "ecdsa",
+ "ecdsa 0.11.1",
  "ff-zeroize",
  "flate2",
  "futures",
@@ -5021,7 +5125,7 @@ dependencies = [
  "iref",
  "json",
  "json-ld",
- "k256",
+ "k256 0.8.1",
  "keccak-hash",
  "lazy_static",
  "multibase 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1067cbcfc0ac6019b51bb292cb51558d8eca1c7c5e3517e5cd192a6c64fec32"
+checksum = "f15e1a2a54bc6bc3f8ea94afafbb374264f8322fcacdae06fefda80a206739ac"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.1.0",
@@ -5195,6 +5195,8 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602d26b7ba20da7425998ff55f7c66f3a747142c3c588dd36bbbe8e06107978d"
 dependencies = [
  "chrono",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +648,9 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cache-padded"
@@ -810,6 +819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "const_fn"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +951,18 @@ name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.4",
  "rand_core 0.6.3",
@@ -1118,7 +1145,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
 dependencies = [
- "const-oid",
+ "const-oid 0.5.2",
  "typenum",
 ]
 
@@ -1127,6 +1154,15 @@ name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.1",
+]
 
 [[package]]
 name = "derive_builder"
@@ -1435,10 +1471,24 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.11",
  "ff 0.10.1",
  "generic-array 0.14.4",
  "group 0.10.0",
+ "rand_core 0.6.3",
+ "subtle 2.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "der 0.5.1",
+ "generic-array 0.14.4",
  "rand_core 0.6.3",
  "subtle 2.4.1",
  "zeroize",
@@ -1473,6 +1523,73 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
+]
+
+[[package]]
+name = "ethabi"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
+dependencies = [
+ "anyhow",
+ "ethereum-types",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types 0.10.1",
+ "uint",
+]
+
+[[package]]
+name = "ethers-core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15e1a2a54bc6bc3f8ea94afafbb374264f8322fcacdae06fefda80a206739ac"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bytes 1.1.0",
+ "ecdsa 0.12.4",
+ "elliptic-curve 0.11.5",
+ "ethabi",
+ "generic-array 0.14.4",
+ "hex",
+ "k256 0.9.6",
+ "once_cell",
+ "rand 0.8.4",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1597,6 +1714,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -2182,6 +2302,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,7 +2569,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0386ec98c26dd721aaa3412bf3a817156ff3ee7cb6959503f8d1095f4ccc51"
 dependencies = [
- "primitive-types",
+ "primitive-types 0.9.1",
  "tiny-keccak",
 ]
 
@@ -3633,6 +3791,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec 0.20.4",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4064,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
  "fixed-hash",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
  "uint",
 ]
 
@@ -4507,6 +4704,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rocket"
 version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,6 +4827,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -4970,17 +5194,16 @@ dependencies = [
 
 [[package]]
 name = "siwe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524f2d6eb394f768b22b3dfd317f1bfcab159fa6ac4268026354384643680f3a"
+version = "0.1.1"
 dependencies = [
  "chrono",
+ "ethers-core",
  "hex",
+ "http",
  "iri-string",
  "k256 0.9.6",
  "sha3",
  "thiserror",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5195,9 +5195,8 @@ dependencies = [
 
 [[package]]
 name = "siwe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602d26b7ba20da7425998ff55f7c66f3a747142c3c588dd36bbbe8e06107978d"
+version = "0.1.2"
+source = "git+https://github.com/spruceid/siwe-rs#3d726634b1063cb0cffbbfcf217cbd8c6141de4e"
 dependencies = [
  "chrono",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5195,8 +5195,9 @@ dependencies = [
 
 [[package]]
 name = "siwe"
-version = "0.1.2"
-source = "git+https://github.com/spruceid/siwe-rs#3d726634b1063cb0cffbbfcf217cbd8c6141de4e"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a371151a398635bf39e36ed90cd34c6264e7fd7bf1fb2337156f06f8ce836c"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -5204,6 +5205,7 @@ dependencies = [
  "http",
  "iri-string",
  "k256 0.9.6",
+ "rand 0.8.4",
  "sha3",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "cached 0.26.2",
  "chrono",
  "didkit",
+ "ethers-core",
  "hex",
  "ipfs-embed",
  "libipld",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15e1a2a54bc6bc3f8ea94afafbb374264f8322fcacdae06fefda80a206739ac"
+checksum = "d1067cbcfc0ac6019b51bb292cb51558d8eca1c7c5e3517e5cd192a6c64fec32"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = "0.1"
+siwe = { path = "../siwe-rs" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = { path = "../siwe-rs" }
+siwe = "0.1.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nom = "6"
 bs58 = "0.4"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-serde_with = "1"
+serde_with = { version = "1", features = ["hex"] }
 hex = "0.4"
 libipld = "0.12"
 tokio-stream = { version = "0.1", features = ["fs"] }
@@ -34,6 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
+siwe = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = "0.1.1"
+siwe = { git = "https://github.com/spruceid/siwe-rs", branch = "fix/uri" }
 ethers-core = "0.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = { git = "https://github.com/spruceid/siwe-rs", branch = "fix/uri" }
+siwe = { git = "https://github.com/spruceid/siwe-rs" }
 ethers-core = "0.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
 siwe = "0.1.1"
+ethers-core = "0.6"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-recursion = "0.3"
 libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = { git = "https://github.com/spruceid/siwe-rs" }
+siwe = "0.1"
 ethers-core = "0.6"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod relay;
 pub mod routes;
 pub mod s3;
 pub mod s3_routes;
+pub mod siwe;
 pub mod tz;
 pub mod tz_orbit;
 pub mod zcap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ pub mod orbit;
 pub mod relay;
 pub mod routes;
 pub mod s3;
-pub mod s3_routes;
 pub mod siwe;
 pub mod tz;
 pub mod tz_orbit;

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -89,10 +89,10 @@ impl<'r> FromRequest<'r> for AuthTokens {
         let ats =
             if let Outcome::Success(tz) = TezosAuthorizationString::from_request(request).await {
                 Self::Tezos(tz)
-            } else if let Outcome::Success(siwe) = SIWEZcapTokens::from_request(request).await {
-                Self::SIWEZcapTokens(siwe)
             } else if let Outcome::Success(siwe) = SIWETokens::from_request(request).await {
                 Self::SIWEDelegated(siwe)
+            } else if let Outcome::Success(siwe) = SIWEZcapTokens::from_request(request).await {
+                Self::SIWEZcapDelegated(siwe)
             } else if let Outcome::Success(zcap) = ZCAPTokens::from_request(request).await {
                 Self::ZCAP(Box::new(zcap))
             } else {
@@ -130,7 +130,7 @@ impl AuthorizationPolicy<AuthTokens> for OrbitMetadata {
             AuthTokens::Tezos(token) => self.authorize(token).await,
             AuthTokens::ZCAP(token) => self.authorize(token.as_ref()).await,
             AuthTokens::SIWEDelegated(token) => self.authorize(token).await,
-            AuthTokens::SIWEZcapDelegated(token) => self.authorize(&token.message).await,
+            AuthTokens::SIWEZcapDelegated(token) => self.authorize(token).await,
         }
     }
 }

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -5,6 +5,7 @@ use crate::{
     config::ExternalApis,
     ipfs::Ipfs,
     s3::{Service, Store},
+    siwe::SIWETokens,
     tz::TezosAuthorizationString,
     tz_orbit::params_to_tz_orbit,
     zcap::ZCAPTokens,
@@ -73,10 +74,10 @@ impl OrbitMetadata {
     }
 }
 
-#[derive(Clone)]
 pub enum AuthTokens {
     Tezos(TezosAuthorizationString),
     ZCAP(Box<ZCAPTokens>),
+    SIWE(SIWETokens),
 }
 
 #[rocket::async_trait]
@@ -89,6 +90,8 @@ impl<'r> FromRequest<'r> for AuthTokens {
                 Self::Tezos(tz)
             } else if let Outcome::Success(zcap) = ZCAPTokens::from_request(request).await {
                 Self::ZCAP(Box::new(zcap))
+            } else if let Outcome::Success(siwe) = SIWETokens::from_request(request).await {
+                Self::SIWE(siwe)
             } else {
                 return Outcome::Failure((
                     Status::Unauthorized,
@@ -104,12 +107,14 @@ impl AuthorizationToken for AuthTokens {
         match self {
             Self::Tezos(token) => token.action(),
             Self::ZCAP(token) => token.action(),
+            Self::SIWE(token) => token.action(),
         }
     }
     fn target_orbit(&self) -> &Cid {
         match self {
             Self::Tezos(token) => token.target_orbit(),
             Self::ZCAP(token) => token.target_orbit(),
+            Self::SIWE(token) => token.target_orbit(),
         }
     }
 }
@@ -119,6 +124,7 @@ impl AuthorizationPolicy<AuthTokens> for OrbitMetadata {
         match auth_token {
             AuthTokens::Tezos(token) => self.authorize(token).await,
             AuthTokens::ZCAP(token) => self.authorize(token.as_ref()).await,
+            AuthTokens::SIWE(token) => self.authorize(token).await,
         }
     }
 }

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -5,7 +5,7 @@ use crate::{
     config::ExternalApis,
     ipfs::Ipfs,
     s3::{Service, Store},
-    siwe::SIWETokens,
+    siwe::{SIWECreate, SIWETokens},
     tz::TezosAuthorizationString,
     tz_orbit::params_to_tz_orbit,
     zcap::ZCAPTokens,
@@ -77,7 +77,8 @@ impl OrbitMetadata {
 pub enum AuthTokens {
     Tezos(TezosAuthorizationString),
     ZCAP(Box<ZCAPTokens>),
-    SIWE(SIWETokens),
+    SIWEDelegated(SIWETokens),
+    SIWECreate(SIWECreate),
 }
 
 #[rocket::async_trait]
@@ -91,7 +92,9 @@ impl<'r> FromRequest<'r> for AuthTokens {
             } else if let Outcome::Success(zcap) = ZCAPTokens::from_request(request).await {
                 Self::ZCAP(Box::new(zcap))
             } else if let Outcome::Success(siwe) = SIWETokens::from_request(request).await {
-                Self::SIWE(siwe)
+                Self::SIWEDelegated(siwe)
+            } else if let Outcome::Success(siwe) = SIWECreate::from_request(request).await {
+                Self::SIWECreate(siwe)
             } else {
                 return Outcome::Failure((
                     Status::Unauthorized,
@@ -107,14 +110,16 @@ impl AuthorizationToken for AuthTokens {
         match self {
             Self::Tezos(token) => token.action(),
             Self::ZCAP(token) => token.action(),
-            Self::SIWE(token) => token.action(),
+            Self::SIWEDelegated(token) => token.action(),
+            Self::SIWECreate(token) => token.action(),
         }
     }
     fn target_orbit(&self) -> &Cid {
         match self {
             Self::Tezos(token) => token.target_orbit(),
             Self::ZCAP(token) => token.target_orbit(),
-            Self::SIWE(token) => token.target_orbit(),
+            Self::SIWEDelegated(token) => token.target_orbit(),
+            Self::SIWECreate(token) => token.target_orbit(),
         }
     }
 }
@@ -124,7 +129,8 @@ impl AuthorizationPolicy<AuthTokens> for OrbitMetadata {
         match auth_token {
             AuthTokens::Tezos(token) => self.authorize(token).await,
             AuthTokens::ZCAP(token) => self.authorize(token.as_ref()).await,
-            AuthTokens::SIWE(token) => self.authorize(token).await,
+            AuthTokens::SIWEDelegated(token) => self.authorize(token).await,
+            AuthTokens::SIWECreate(token) => self.authorize(&token.message).await,
         }
     }
 }
@@ -345,12 +351,17 @@ pub fn get_params(matrix_params: &str) -> Result<Map<String, String>> {
         .collect::<Result<Map<String, String>>>()
 }
 
+pub fn hash_same<B: AsRef<[u8]>>(c: &Cid, b: B) -> Result<Cid> {
+    Ok(Cid::new_v1(
+        c.codec(),
+        Code::try_from(c.hash().code())?.digest(b.as_ref()),
+    ))
+}
+
 pub fn verify_oid(oid: &Cid, uri_str: &str) -> Result<(String, Map<String, String>)> {
     // try to parse as a URI with matrix params
-    if &Code::try_from(oid.hash().code())?.digest(uri_str.as_bytes()) == oid.hash()
-        && oid.codec() == 0x55
-    {
-        let first_sc = uri_str.find(';').unwrap_or_else(|| uri_str.len());
+    if &hash_same(oid, uri_str)? == oid && oid.codec() == 0x55 {
+        let first_sc = uri_str.find(";").unwrap_or(uri_str.len());
         Ok((
             // method name
             uri_str

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -89,12 +89,12 @@ impl<'r> FromRequest<'r> for AuthTokens {
         let ats =
             if let Outcome::Success(tz) = TezosAuthorizationString::from_request(request).await {
                 Self::Tezos(tz)
-            } else if let Outcome::Success(zcap) = ZCAPTokens::from_request(request).await {
-                Self::ZCAP(Box::new(zcap))
             } else if let Outcome::Success(siwe) = SIWETokens::from_request(request).await {
                 Self::SIWEDelegated(siwe)
             } else if let Outcome::Success(siwe) = SIWECreate::from_request(request).await {
                 Self::SIWECreate(siwe)
+            } else if let Outcome::Success(zcap) = ZCAPTokens::from_request(request).await {
+                Self::ZCAP(Box::new(zcap))
             } else {
                 return Outcome::Failure((
                     Status::Unauthorized,

--- a/src/s3/entries.rs
+++ b/src/s3/entries.rs
@@ -206,7 +206,7 @@ mod test {
 
         let write = IpfsWriteStream::new(&ipfs)?;
         tracing::debug!("write");
-        let (o, pins) = write.write(Cursor::new(data.clone())).await?;
+        let (o, _pins) = write.write(Cursor::new(data.clone())).await?;
 
         let content = ipfs.get(&o)?.decode::<DagCborCodec, Vec<(Cid, u32)>>()?;
 

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -1,29 +1,57 @@
 use crate::{
     auth::{Action, AuthorizationPolicy, AuthorizationToken},
-    orbit::OrbitMetadata,
+    orbit::{hash_same, OrbitMetadata},
     zcap::KeplerInvocation,
 };
 use anyhow::Result;
 use didkit::DID_METHODS;
 use ipfs_embed::Cid;
+use libipld::cid::multihash::{Code, MultihashDigest};
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},
 };
+
+use hex::FromHex;
 use serde::{Deserialize, Serialize};
-use serde_with::{hex::Hex, serde_as, DisplayFromStr};
+use serde_with::{serde_as, DisplayFromStr};
 use siwe::eip4361::Message;
+use std::str::FromStr;
+
+pub struct SIWESignature([u8; 65]);
+
+impl core::fmt::Display for SIWESignature {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
+impl FromStr for SIWESignature {
+    type Err = anyhow::Error;
+    fn from_str<'a>(s: &'a str) -> Result<Self, Self::Err> {
+        match s.split_once("0x") {
+            Some(("", h)) => Ok(Self(<[u8; 65]>::from_hex(h)?)),
+            _ => Err(anyhow!("Invalid hex string, no leading 0x")),
+        }
+    }
+}
 
 #[serde_as]
 #[derive(Serialize, Deserialize)]
-pub struct SIWEDelegation(
+pub struct SIWEMessage(
     #[serde_as(as = "DisplayFromStr")] Message,
-    #[serde_as(as = "Hex")] [u8; 65],
+    #[serde_as(as = "DisplayFromStr")] SIWESignature,
 );
 
 pub struct SIWETokens {
     pub invocation: KeplerInvocation,
-    pub delegation: SIWEDelegation,
+    pub delegation: SIWEMessage,
+}
+
+pub struct SIWECreate {
+    pub message: SIWEMessage,
+    pub orbit: Cid,
+    pub action: Action,
 }
 
 #[rocket::async_trait]
@@ -53,12 +81,67 @@ impl<'r> FromRequest<'r> for SIWETokens {
     }
 }
 
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for SIWECreate {
+    type Error = anyhow::Error;
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match request.headers().get_one("x-siwe-invocation").map(|b64| {
+            base64::decode_config(b64, base64::URL_SAFE)
+                .map_err(|e| anyhow!(e))
+                .and_then(|s| Ok(serde_json::from_slice(&s)?))
+                .and_then(|message: SIWEMessage| {
+                    let params = &message
+                        .0
+                        .uri
+                        .as_str()
+                        .split_once("kepler://")
+                        .and_then(|u| match u {
+                            ("", p) => Some(p),
+                            _ => None,
+                        })
+                        .ok_or_else(|| anyhow!("Invalid URI"))?;
+
+                    Ok(SIWECreate {
+                        orbit: match params.parse() {
+                            Ok(cid) => cid,
+                            Err(_) => Cid::new_v1(0x55, Code::Blake2b256.digest(params.as_bytes())),
+                        },
+                        action: match &message.0.resources.first().map(|u| u.as_str()) {
+                            Some("#host") => Ok(Action::Create {
+                                parameters: params.to_string(),
+                                content: vec![],
+                            }),
+                            _ => Err(anyhow!("Incorrect resources")),
+                        }?,
+                        message,
+                    })
+                })
+        }) {
+            Some(Ok(invocation)) => Outcome::Success(invocation),
+            Some(Err(e)) => {
+                tracing::debug!("{}", e);
+                Outcome::Failure((Status::Unauthorized, e))
+            }
+            None => Outcome::Forward(()),
+        }
+    }
+}
+
 impl AuthorizationToken for SIWETokens {
     fn action(&self) -> &Action {
         &self.invocation.property_set.capability_action
     }
     fn target_orbit(&self) -> &Cid {
         &self.invocation.property_set.invocation_target
+    }
+}
+
+impl AuthorizationToken for SIWECreate {
+    fn action(&self) -> &Action {
+        &self.action
+    }
+    fn target_orbit(&self) -> &Cid {
+        &self.orbit
     }
 }
 
@@ -76,17 +159,34 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
         ) {
             return Err(anyhow!("Delegator not authorized"));
         };
+
+        let invoker = auth_token
+            .invocation
+            .proof
+            .as_ref()
+            .and_then(|proof| proof.verification_method.as_ref())
+            .ok_or_else(|| anyhow!("Missing invoker verification method"))?;
+
         // check delegation to invoker
-        if auth_token.delegation.0.uri.as_str()
-            != auth_token
+        if auth_token.delegation.0.uri.as_str() != invoker {
+            tracing::debug!("{}, {}", auth_token.delegation.0.uri.as_str(), invoker);
+            return Err(anyhow!("Invoker not authorized"));
+        };
+
+        // check invoker invokes delegation
+        if &format!("urn:siwe:kepler:{}", auth_token.delegation.0.nonce)
+            != &auth_token
                 .invocation
                 .proof
                 .as_ref()
-                .and_then(|proof| proof.verification_method.as_ref())
-                .ok_or_else(|| anyhow!("Missing delegation verification method"))?
+                .and_then(|p| p.property_set.as_ref())
+                .and_then(|s| s.get("capability"))
+                .and_then(|c| c.as_str())
+                .ok_or_else(|| anyhow!("Invalid capability in invocation proof"))?
         {
-            return Err(anyhow!("Invoker not authorized"));
+            return Err(anyhow!("Invocation is not for given Delegation"));
         };
+
         // check delegation time validity
         if !auth_token.delegation.0.valid_now() {
             return Err(anyhow!("Delegation has Expired"));
@@ -126,7 +226,7 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
         auth_token
             .delegation
             .0
-            .verify_eip191(auth_token.delegation.1)?;
+            .verify_eip191(&auth_token.delegation.1 .0)?;
 
         match auth_token
             .invocation
@@ -138,6 +238,45 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
             Some(e) => Err(anyhow!(e)),
             None => Ok(()),
         }
+    }
+}
+
+#[rocket::async_trait]
+impl AuthorizationPolicy<SIWEMessage> for OrbitMetadata {
+    async fn authorize(&self, auth_token: &SIWEMessage) -> Result<()> {
+        // check address is controller
+        if !self.controllers().contains(
+            &format!(
+                "did:pkh:eip155:{}:0x{}#blockchainAccountId",
+                &auth_token.0.chain_id,
+                &hex::encode(auth_token.0.address)
+            )
+            .parse()?,
+        ) {
+            return Err(anyhow!("Delegator not authorized"));
+        };
+        // check orbit ID
+        if self.id()
+            != &auth_token
+                .0
+                .uri
+                .as_str()
+                .split_once("kepler://")
+                .ok_or_else(|| anyhow!("Invalid URI"))
+                .and_then(|(_, p)| match Cid::from_str(p) {
+                    Ok(oid) => Ok(oid),
+                    Err(e) => hash_same(self.id(), p),
+                })?
+        {
+            return Err(anyhow!("Incorrect Orbit ID"));
+        };
+        // check time validity
+        if !auth_token.0.valid_now() {
+            return Err(anyhow!("Message has Expired"));
+        };
+
+        auth_token.0.verify_eip191(&auth_token.1 .0)?;
+        Ok(())
     }
 }
 

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -1,0 +1,147 @@
+use crate::{
+    auth::{Action, AuthorizationPolicy, AuthorizationToken},
+    orbit::OrbitMetadata,
+    zcap::KeplerInvocation,
+};
+use anyhow::Result;
+use didkit::DID_METHODS;
+use ipfs_embed::Cid;
+use rocket::{
+    http::Status,
+    request::{FromRequest, Outcome, Request},
+};
+use serde::{Deserialize, Serialize};
+use serde_with::{hex::Hex, serde_as, DisplayFromStr};
+use siwe::eip4361::Message;
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct SIWEDelegation(
+    #[serde_as(as = "DisplayFromStr")] Message,
+    #[serde_as(as = "Hex")] [u8; 65],
+);
+
+pub struct SIWETokens {
+    pub invocation: KeplerInvocation,
+    pub delegation: SIWEDelegation,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for SIWETokens {
+    type Error = anyhow::Error;
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match (
+            request.headers().get_one("x-kepler-invocation").map(|b64| {
+                base64::decode_config(b64, base64::URL_SAFE)
+                    .map_err(|e| anyhow!(e))
+                    .and_then(|s| serde_json::from_slice(&s).map_err(|e| anyhow!(e)))
+            }),
+            request.headers().get_one("x-siwe-delegation").map(|b64| {
+                base64::decode_config(b64, base64::URL_SAFE)
+                    .map_err(|e| anyhow!(e))
+                    .and_then(|s| serde_json::from_slice(&s).map_err(|e| anyhow!(e)))
+            }),
+        ) {
+            (Some(Ok(invocation)), Some(Ok(delegation))) => Outcome::Success(Self {
+                invocation,
+                delegation,
+            }),
+            (Some(Err(e)), _) => Outcome::Failure((Status::Unauthorized, e)),
+            (_, Some(Err(e))) => Outcome::Failure((Status::Unauthorized, e)),
+            (_, _) => Outcome::Forward(()),
+        }
+    }
+}
+
+impl AuthorizationToken for SIWETokens {
+    fn action(&self) -> &Action {
+        &self.invocation.property_set.capability_action
+    }
+    fn target_orbit(&self) -> &Cid {
+        &self.invocation.property_set.invocation_target
+    }
+}
+
+#[rocket::async_trait]
+impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
+    async fn authorize(&self, auth_token: &SIWETokens) -> Result<()> {
+        // check delegator is controller
+        if !self.controllers().contains(
+            &format!(
+                "did:pkh:eip155:{}:0x{}#blockchainAccountId",
+                &auth_token.delegation.0.chain_id,
+                &hex::encode(auth_token.delegation.0.address)
+            )
+            .parse()?,
+        ) {
+            return Err(anyhow!("Delegator not authorized"));
+        };
+        // check delegation to invoker
+        if auth_token.delegation.0.uri.as_str()
+            != auth_token
+                .invocation
+                .proof
+                .as_ref()
+                .and_then(|proof| proof.verification_method.as_ref())
+                .ok_or_else(|| anyhow!("Missing delegation verification method"))?
+        {
+            return Err(anyhow!("Invoker not authorized"));
+        };
+        // check delegation time validity
+        if !auth_token.delegation.0.valid_now() {
+            return Err(anyhow!("Delegation has Expired"));
+        };
+
+        // check action is authorized by blanket root ("." as relative path against "kepler://<orbit-id>/") auth
+        if !auth_token.delegation.0.resources.contains(&match auth_token
+            .invocation
+            .property_set
+            .capability_action
+        {
+            Action::List => format!(
+                "kepler://{}#list",
+                &auth_token.invocation.property_set.invocation_target
+            )
+            .parse()?,
+            Action::Put(_) => format!(
+                "kepler://{}#put",
+                &auth_token.invocation.property_set.invocation_target
+            )
+            .parse()?,
+            Action::Get(_) => format!(
+                "kepler://{}#get",
+                &auth_token.invocation.property_set.invocation_target
+            )
+            .parse()?,
+            Action::Del(_) => format!(
+                "kepler://{}#del",
+                &auth_token.invocation.property_set.invocation_target
+            )
+            .parse()?,
+            _ => return Err(anyhow!("Invalid Action")),
+        }) {
+            return Err(anyhow!("Invoked action not authorized by delegation"));
+        };
+
+        auth_token
+            .delegation
+            .0
+            .verify_eip191(auth_token.delegation.1)?;
+
+        match auth_token
+            .invocation
+            .verify_signature(Default::default(), DID_METHODS.to_resolver())
+            .await
+            .errors
+            .pop()
+        {
+            Some(e) => Err(anyhow!(e)),
+            None => Ok(()),
+        }
+    }
+}
+
+#[test]
+async fn basic() -> Result<()> {
+    Ok(())
+}

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -60,7 +60,7 @@ pub struct SIWETokens {
     pub delegation: Option<SIWEMessage>,
     // kinda weird
     pub orbit: Cid,
-    pub action: Action,
+    pub invoked_action: Action,
 }
 
 #[rocket::async_trait]
@@ -177,7 +177,7 @@ impl<'r> FromRequest<'r> for SIWETokens {
             invocation,
             delegation,
             orbit,
-            action,
+            invoked_action: action,
         })
     }
 }
@@ -193,7 +193,7 @@ impl AuthorizationToken for SIWEZcapTokens {
 
 impl AuthorizationToken for SIWETokens {
     fn action(&self) -> &Action {
-        &self.action
+        &self.invoked_action
     }
     fn target_orbit(&self) -> &Cid {
         &self.orbit

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -195,7 +195,7 @@ impl AuthorizationPolicy<SIWEZcapTokens> for OrbitMetadata {
             &format!(
                 "did:pkh:eip155:{}:0x{}#blockchainAccountId",
                 &auth_token.delegation.0.chain_id,
-                &to_checksum(&H160(auth_token.delegation.0.address), None)
+                &hex::encode(&auth_token.delegation.0.address)
             )
             .parse()?,
         ) {
@@ -266,7 +266,7 @@ impl AuthorizationPolicy<SIWEZcapTokens> for OrbitMetadata {
 
         auth_token
             .delegation
-            .verify_eip191(auth_token.delegation.1 .0)?;
+            .verify_eip191(&auth_token.delegation.1 .0)?;
 
         match auth_token
             .invocation
@@ -307,7 +307,7 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
                 ) {
                     return Err(anyhow!("Delegator not authorized"));
                 };
-                d.verify_eip191(d.1 .0)?;
+                d.verify_eip191(&d.1 .0)?;
 
                 if &d.uri != &invoker
                     && !(d.uri.as_str().ends_with("*")
@@ -326,7 +326,7 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
                     )
                     .parse()?,
                 ) {
-                    return Err(anyhow!("Delegator not authorized"));
+                    return Err(anyhow!("Invoker not authorized as Controller"));
                 };
             }
         };
@@ -337,7 +337,7 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
             return Err(anyhow!("Message has Expired"));
         };
 
-        t.invocation.verify_eip191(t.invocation.1 .0)?;
+        t.invocation.verify_eip191(&t.invocation.1 .0)?;
 
         Ok(())
     }

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use siwe::eip4361::Message;
 use std::{ops::Deref, str::FromStr};
+use ethers_core::{types::H160, utils::to_checksum};
 
 pub struct SIWESignature([u8; 65]);
 
@@ -194,7 +195,7 @@ impl AuthorizationPolicy<SIWEZcapTokens> for OrbitMetadata {
             &format!(
                 "did:pkh:eip155:{}:0x{}#blockchainAccountId",
                 &auth_token.delegation.0.chain_id,
-                &hex::encode(auth_token.delegation.0.address)
+                &to_checksum(&H160(auth_token.delegation.0.address), None)
             )
             .parse()?,
         ) {

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::{Action, AuthorizationPolicy, AuthorizationToken},
-    orbit::{hash_same, OrbitMetadata},
+    orbit::OrbitMetadata,
     zcap::KeplerInvocation,
 };
 use anyhow::Result;
@@ -28,7 +28,7 @@ impl core::fmt::Display for SIWESignature {
 
 impl FromStr for SIWESignature {
     type Err = anyhow::Error;
-    fn from_str<'a>(s: &'a str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.split_once("0x") {
             Some(("", h)) => Ok(Self(<[u8; 65]>::from_hex(h)?)),
             _ => Err(anyhow!("Invalid hex string, no leading 0x")),
@@ -228,8 +228,8 @@ impl AuthorizationPolicy<SIWEZcapTokens> for OrbitMetadata {
         };
 
         // check invoker invokes delegation
-        if &format!("urn:siwe:kepler:{}", auth_token.delegation.nonce)
-            != &auth_token
+        if format!("urn:siwe:kepler:{}", auth_token.delegation.nonce)
+            != auth_token
                 .invocation
                 .proof
                 .as_ref()
@@ -322,8 +322,8 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
                 };
                 d.verify_eip191(&d.1 .0)?;
 
-                if &d.uri != &invoker
-                    && !(d.uri.as_str().ends_with("*")
+                if d.uri != invoker
+                    && !(d.uri.as_str().ends_with('*')
                         && invoker.starts_with(&d.uri.as_str()[..&d.uri.as_str().len() - 1]))
                 {
                     return Err(anyhow!("Invoker not authorized"));
@@ -352,6 +352,6 @@ impl AuthorizationPolicy<SIWETokens> for OrbitMetadata {
 #[test]
 async fn basic() -> Result<()> {
     let d = r#"["localhost wants you to sign in with your Ethereum account:\n0xA391f7adD776806c4dFf3886BBe6370be8F73683\n\nAllow localhost to access your orbit using their temporary session key: did:key:z6MksaFv5D1zYGCvDt2fEvDQWhVcMcaSieMmCSc54DDq3Rwh#z6MksaFv5D1zYGCvDt2fEvDQWhVcMcaSieMmCSc54DDq3Rwh\n\nURI: did:key:z6MksaFv5D1zYGCvDt2fEvDQWhVcMcaSieMmCSc54DDq3Rwh#z6MksaFv5D1zYGCvDt2fEvDQWhVcMcaSieMmCSc54DDq3Rwh\nVersion: 1\nChain ID: 1\nNonce: Ki63qhXvxk0LYfxRE\nIssued At: 2021-12-08T13:09:59.716Z\nExpiration Time: 2021-12-08T13:24:59.715Z\nResources:\n- kepler://bafk2bzacedmmmpdngsjom66fob3gy3727fvc7dqqirlec3uyei7v2edmueazk#put\n- kepler://bafk2bzacedmmmpdngsjom66fob3gy3727fvc7dqqirlec3uyei7v2edmueazk#del\n- kepler://bafk2bzacedmmmpdngsjom66fob3gy3727fvc7dqqirlec3uyei7v2edmueazk#get\n- kepler://bafk2bzacedmmmpdngsjom66fob3gy3727fvc7dqqirlec3uyei7v2edmueazk#list","0x3c79ff9c565939bc4d43ac45d92f685de61b756a1ba9c0a8a5a80d177f05f29b7b27df1dc1c331397eef837d96b95dd812ce78c1b29a05c2b0c0bdd901be72351b"]"#;
-    let message: SIWEMessage = serde_json::from_str(d)?;
+    let _message: SIWEMessage = serde_json::from_str(d)?;
     Ok(())
 }

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -161,23 +161,8 @@ impl AuthorizationPolicy<ZCAPTokens> for OrbitMetadata {
                 res
             }
             None => {
-                match auth_token.invocation.property_set.capability_action {
-                    Action::List | Action::Get(_) => {
-                        if !self.read_delegators.contains(&invoker_vm)
-                            && !self.write_delegators.contains(&invoker_vm)
-                            && !self.controllers.contains(&invoker_vm)
-                        {
-                            return Err(anyhow!("Invoker not authorized"));
-                        }
-                    }
-                    Action::Put(_) | Action::Del(_) => {
-                        if !self.write_delegators.contains(&invoker_vm)
-                            && !self.controllers.contains(&invoker_vm)
-                        {
-                            return Err(anyhow!("Invoker not authorized"));
-                        }
-                    }
-                    Action::Create { .. } => {}
+                if !self.controllers.contains(&invoker_vm) {
+                    return Err(anyhow!("Invoker not authorized as Controller"));
                 };
                 auth_token
                     .invocation


### PR DESCRIPTION
Implements resource access authorization (delegation and invocation) using EIP-4361 Sign In With Ethereum. Clients can delegate and invoke capabilities via encoding them as resource URIs in a SIWE message. SIWE and ZCAP messages can be used together in delegation chains (e.g. a ZCAP delegation and a SIWE invocation, and vice versa). This implementation contains much complexity that would be better abstracted/refactored in future, as the different combinations are implemented "manually".