### PR TITLE
Fix clippy warnings in tests

### DIFF
--- a/src/relay.rs
+++ b/src/relay.rs
@@ -116,7 +116,7 @@ mod test {
             &alice.local_peer_id(),
             relay
                 .external()
-                .with(Protocol::P2p(relay.id.clone().into()))
+                .with(Protocol::P2p(relay.id.into()))
                 .with(Protocol::P2pCircuit)
                 .with(Protocol::P2p(alice.local_peer_id().into())),
         );

--- a/src/s3/entries.rs
+++ b/src/s3/entries.rs
@@ -201,12 +201,12 @@ mod test {
         let tmp = tempdir::TempDir::new("test_streams")?;
         let data = vec![3u8; KeplerParams::MAX_BLOCK_SIZE * 3];
 
-        let config = ipfs_embed::Config::new(&tmp.path(), ipfs_embed::generate_keypair());
+        let config = ipfs_embed::Config::new(tmp.path(), ipfs_embed::generate_keypair());
         let ipfs = Ipfs::new(config).await?;
 
         let write = IpfsWriteStream::new(&ipfs)?;
         tracing::debug!("write");
-        let (o, pins) = write.write(Cursor::new(data.clone())).await?;
+        let (o, _pins) = write.write(Cursor::new(data.clone())).await?;
 
         let content = ipfs.get(&o)?.decode::<DagCborCodec, Vec<(Cid, u32)>>()?;
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -183,7 +183,8 @@ mod test {
         let s3_obj_1 = ObjectBuilder::new(key1.as_bytes().to_vec(), md.clone());
         let s3_obj_2 = ObjectBuilder::new(key2.as_bytes().to_vec(), md.clone());
 
-        let rm: Vec<(Vec<u8>, Option<(u64, Cid)>)> = vec![];
+        type RmItem = (Vec<u8>, Option<(u64, Cid)>);
+        let rm: Vec<RmItem> = vec![];
         alice_service
             .write(vec![(s3_obj_1, json.as_bytes())], rm.clone())
             .await?;

--- a/src/tz.rs
+++ b/src/tz.rs
@@ -292,13 +292,13 @@ async fn round_trip() {
     let did = DID_METHODS
         .generate(&Source::KeyAndPattern(&j, "tz"))
         .unwrap();
-    let pkh = did.split(":").last().unwrap();
+    let pkh = did.split(':').last().unwrap();
     let pk: String = match &j.params {
         Params::OKP(p) => bs58::encode(
             [13, 15, 37, 217]
                 .iter()
                 .chain(&p.public_key.0)
-                .map(|&x| x)
+                .copied()
                 .collect::<Vec<u8>>(),
         )
         .with_check()
@@ -322,7 +322,7 @@ async fn round_trip() {
         [9, 245, 205, 134, 18]
             .iter()
             .chain(&sig_bytes)
-            .map(|&x| x)
+            .copied()
             .collect::<Vec<u8>>(),
     )
     .with_check()


### PR DESCRIPTION
This is a somewhat trivial PR but it fixes all of the warnings yielded by `cargo clippy --tests`.