### PR TITLE
Switch out ipfs-embed for rust-ipfs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,17 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bao"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0459c2bb916c8dd306cdb368bd09ff245763b9d6be6ccc7e2b8a3975eda3c9c"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.2",
- "blake3",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,25 +440,6 @@ dependencies = [
  "radium 0.6.2",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake-streams-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5ea96bd3f1623fd4ccb2f3cd6818eb967c448395e2f1c8165446a6e2dc02cd"
-dependencies = [
- "anyhow",
- "bao",
- "base64 0.13.0",
- "ed25519-dalek",
- "fnv",
- "getrandom 0.2.3",
- "parking_lot",
- "rkyv",
- "sled",
- "tracing",
- "zerocopy",
 ]
 
 [[package]]
@@ -609,27 +579,6 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb738a1e65989ecdcd5bba16079641bd7209688fa546e1064832fd6e012fd32a"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b4dff26fdc9f847dab475c9fec16f2cba82d5aa1f09981b87c44520721e10a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "byteorder"
@@ -774,8 +723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b8976b33648136e969aafa6eb33d58ff0d301fa0b4e8d513db58fd32cd81aa"
 dependencies = [
  "multibase 0.9.1",
- "multihash",
- "unsigned-varint",
+ "multihash 0.14.0",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -835,12 +784,6 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -1186,19 +1129,6 @@ dependencies = [
  "darling 0.10.2",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -1627,18 +1557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1624,18 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
@@ -2061,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash_hasher"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,15 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
-dependencies = [
- "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2378,48 +2305,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipfs-embed"
-version = "0.22.4"
-source = "git+https://github.com/spruceid/ipfs-embed?branch=feat/p2pcircuit-v1#1feedd1420b5b829d17a15403d343399a35c286a"
+name = "ipfs"
+version = "0.2.1"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
 dependencies = [
  "anyhow",
- "async-io",
+ "async-stream",
  "async-trait",
- "fnv",
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.1.0",
+ "either",
+ "fs2",
  "futures",
- "futures-timer",
- "ipfs-sqlite-block-store",
- "lazy_static",
+ "hash_hasher",
+ "ipfs-bitswap",
+ "ipfs-unixfs",
  "libipld",
  "libp2p",
- "libp2p-bitswap",
- "libp2p-blake-streams",
- "libp2p-broadcast",
- "libp2p-quic",
- "names",
- "parking_lot",
- "pin-project 1.0.8",
- "prometheus",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sled",
  "thiserror",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "tracing",
+ "tracing-futures",
+ "trust-dns-resolver",
  "void",
 ]
 
 [[package]]
-name = "ipfs-sqlite-block-store"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05e414ba0fd10cd9e188230916214b6d6e39b6b340a892b977db9b42a2b6ac4"
+name = "ipfs-bitswap"
+version = "0.1.0"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
 dependencies = [
- "anyhow",
- "derive_more",
  "fnv",
  "futures",
+ "hash_hasher",
  "libipld",
- "parking_lot",
- "rusqlite",
+ "libp2p-core",
+ "libp2p-swarm",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
+ "thiserror",
+ "tokio",
  "tracing",
+ "unsigned-varint 0.7.0",
+]
+
+[[package]]
+name = "ipfs-unixfs"
+version = "0.2.0"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
+dependencies = [
+ "either",
+ "filetime",
+ "libipld",
+ "multihash 0.11.4",
+ "quick-protobuf",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2587,7 +2534,7 @@ dependencies = [
  "didkit",
  "ethers-core",
  "hex",
- "ipfs-embed",
+ "ipfs",
  "libipld",
  "libp2p",
  "nom",
@@ -2602,6 +2549,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
@@ -2663,7 +2611,7 @@ dependencies = [
  "libipld-macro",
  "libipld-pb",
  "log",
- "multihash",
+ "multihash 0.14.0",
  "parking_lot",
  "thiserror",
 ]
@@ -2700,7 +2648,7 @@ dependencies = [
  "anyhow",
  "cid",
  "multibase 0.9.1",
- "multihash",
+ "multihash 0.14.0",
  "thiserror",
 ]
 
@@ -2712,7 +2660,7 @@ checksum = "3cf3a6d0e65a5b3f48774f99951d063bc28f7fd799be0a3891de4b10939434e3"
 dependencies = [
  "base64 0.13.0",
  "libipld-core",
- "multihash",
+ "multihash 0.14.0",
  "serde",
  "serde_json",
 ]
@@ -2778,51 +2726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-bitswap"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8e698cfd7957f2d8865fd765efb45dee026cb4f1c1699f7ae57069c5796a64"
-dependencies = [
- "async-trait",
- "fnv",
- "futures",
- "lazy_static",
- "libipld",
- "libp2p",
- "prometheus",
- "thiserror",
- "tracing",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-blake-streams"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bccba9d69fd351782353526462e2529848d85339bec9f4ba8633247704ce5ff"
-dependencies = [
- "anyhow",
- "async-trait",
- "blake-streams-core",
- "fnv",
- "futures",
- "libp2p",
- "tracing",
- "zerocopy",
-]
-
-[[package]]
-name = "libp2p-broadcast"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b652d72fe39c12745c38b358de0cb2964ca71362e2edc1c97622d87068ed3e5e"
-dependencies = [
- "fnv",
- "futures",
- "libp2p",
-]
-
-[[package]]
 name = "libp2p-core"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +2742,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multiaddr",
- "multihash",
+ "multihash 0.14.0",
  "multistream-select",
  "parking_lot",
  "pin-project 1.0.8",
@@ -2851,7 +2754,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "void",
  "zeroize",
 ]
@@ -2921,7 +2824,7 @@ dependencies = [
  "regex",
  "sha2 0.9.8",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "wasm-timer",
 ]
 
@@ -2962,7 +2865,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "void",
  "wasm-timer",
 ]
@@ -3003,7 +2906,7 @@ dependencies = [
  "parking_lot",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -3056,7 +2959,7 @@ dependencies = [
  "log",
  "prost 0.8.0",
  "prost-build 0.8.0",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "void",
 ]
 
@@ -3072,31 +2975,6 @@ dependencies = [
  "rand 0.7.3",
  "salsa20",
  "sha3",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efab133f41ec02c6554c10c31e919f24ccca21c61316b1ddc473d1604fc3728a"
-dependencies = [
- "anyhow",
- "async-global-executor",
- "async-io",
- "bytes 1.1.0",
- "ed25519-dalek",
- "fnv",
- "futures",
- "if-watch",
- "libp2p",
- "multihash",
- "parking_lot",
- "quinn-noise",
- "quinn-proto",
- "rand_core 0.5.1",
- "thiserror",
- "tracing",
- "udp-socket",
 ]
 
 [[package]]
@@ -3117,7 +2995,7 @@ dependencies = [
  "prost-build 0.8.0",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "void",
  "wasm-timer",
 ]
@@ -3138,7 +3016,7 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "wasm-timer",
 ]
 
@@ -3290,17 +3168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3508,11 +3375,11 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multihash 0.14.0",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
  "url",
 ]
 
@@ -3540,6 +3407,21 @@ dependencies = [
 
 [[package]]
 name = "multihash"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest 0.9.0",
+ "sha-1 0.9.8",
+ "sha2 0.9.8",
+ "sha3",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
@@ -3552,7 +3434,7 @@ dependencies = [
  "multihash-derive",
  "sha2 0.9.8",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -3586,16 +3468,7 @@ dependencies = [
  "log",
  "pin-project 1.0.8",
  "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
-name = "names"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
-dependencies = [
- "rand 0.3.23",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -4150,21 +4023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
-dependencies = [
- "cfg-if 1.0.0",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,36 +4125,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca6639207ac869e31cca06b8adbc7676278f22b321e51115766009b4f192dbb"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "quicksink"
@@ -4307,42 +4148,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.1.12",
-]
-
-[[package]]
-name = "quinn-noise"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c50d22f398d489a79753d17bab5a6f9fb48e5cc537ce50b0bb9312ae07ea9"
-dependencies = [
- "bytes 1.1.0",
- "chacha20poly1305",
- "curve25519-dalek",
- "ed25519-dalek",
- "quinn-proto",
- "rand_core 0.5.1",
- "ring",
- "sha2 0.9.8",
- "subtle 2.4.1",
- "tracing",
- "x25519-dalek",
- "xoodoo",
- "zeroize",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047aa96ec7ee6acabad7a1318dff72e9aff8994316bf2166c9b94cbec78ca54c"
-dependencies = [
- "bytes 1.1.0",
- "rand 0.8.4",
- "ring",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
 ]
 
 [[package]]
@@ -4365,16 +4170,6 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
-
-[[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
 
 [[package]]
 name = "rand"
@@ -4495,12 +4290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rawbytes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d0088f16afb86d12c7f239d8de4637fa68ecc99a3db227e1ab58a294713e60"
-
-[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,15 +4388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rend"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0351a2e529ee30d571ef31faa5a4e0b9addaad087697b77efb20d2809e41c7"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,31 +4457,6 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419b2e30d088b21c4bf3072561535305df8066e89937ad05fc205b99874c23c"
-dependencies = [
- "bytecheck",
- "hashbrown 0.11.2",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae58c4ba80f15f2f0842f4c61729e92c4e33a09bd78196c2b1ab9b0771a3ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4806,21 +4561,6 @@ dependencies = [
  "time 0.2.27",
  "tokio",
  "uncased",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "memchr",
- "smallvec",
 ]
 
 [[package]]
@@ -4944,12 +4684,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -5196,8 +4930,7 @@ dependencies = [
 [[package]]
 name = "siwe"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a371151a398635bf39e36ed90cd34c6264e7fd7bf1fb2337156f06f8ce836c"
+source = "git+https://github.com/spruceid/siwe-rs#6f92676a7b7fa23f5d7f98e0553dc0134d644019"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -5743,6 +5476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
@@ -5766,6 +5500,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project 1.0.8",
+ "tracing",
 ]
 
 [[package]]
@@ -5903,18 +5649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "udp-socket"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab965d55b986832d7aefec8778caf524fa14ab0f7fe79588ebc85da4a83f0572"
-dependencies = [
- "async-io",
- "futures-lite",
- "libc",
- "socket2 0.4.2",
-]
-
-[[package]]
 name = "uint"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5978,6 +5712,12 @@ dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.1",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"
@@ -6285,16 +6025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xoodoo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d3c62cbaa9cfdecac0b6aaac5cef3fae1de43c858ac902d6f78b6ee0926107"
-dependencies = [
- "rawbytes",
- "zeroize",
-]
-
-[[package]]
 name = "yamux"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6313,27 +6043,6 @@ name = "yansi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
-
-[[package]]
-name = "zerocopy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af017aca1fa6181f5dd7a802456fe6f7666ecdcc18d0910431f0fc89d474e51"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "ipfs"
 version = "0.2.1"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ipfs-bitswap"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
 dependencies = [
  "fnv",
  "futures",
@@ -2359,12 +2359,13 @@ dependencies = [
 [[package]]
 name = "ipfs-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
 dependencies = [
  "either",
  "filetime",
  "libipld",
  "quick-protobuf",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2545,12 +2546,14 @@ dependencies = [
  "sled",
  "ssi",
  "tempdir",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "void",
 ]
 
 [[package]]
@@ -4912,8 +4915,8 @@ dependencies = [
 
 [[package]]
 name = "siwe"
-version = "0.1.3"
-source = "git+https://github.com/spruceid/siwe-rs#6f92676a7b7fa23f5d7f98e0553dc0134d644019"
+version = "0.2.0"
+source = "git+https://github.com/spruceid/siwe-rs#137c3f0f430a6d5c060c7764ee6c54d8b7857f8b"
 dependencies = [
  "chrono",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "ipfs"
 version = "0.2.1"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
+source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ipfs-bitswap"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
+source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
 dependencies = [
  "fnv",
  "futures",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ipfs-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#d8b6759c7762bac83290059ccf6b06d8bfd3b0fe"
+source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
 dependencies = [
  "either",
  "filetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "ipfs"
 version = "0.2.1"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#c2e7b4dfe8c8a5bb39a10729309835d9298b75b3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ipfs-bitswap"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#c2e7b4dfe8c8a5bb39a10729309835d9298b75b3"
 dependencies = [
  "fnv",
  "futures",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ipfs-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#c2e7b4dfe8c8a5bb39a10729309835d9298b75b3"
 dependencies = [
  "either",
  "filetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,8 +723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b8976b33648136e969aafa6eb33d58ff0d301fa0b4e8d513db58fd32cd81aa"
 dependencies = [
  "multibase 0.9.1",
- "multihash 0.14.0",
- "unsigned-varint 0.7.0",
+ "multihash",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "ipfs"
 version = "0.2.1"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ipfs-bitswap"
 version = "0.1.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
 dependencies = [
  "fnv",
  "futures",
@@ -2353,20 +2353,18 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "ipfs-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/spruceid/rust-ipfs?branch=feat/libipld#33bcc88b49647cf2d5a585a02059ed5de0357528"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#017c91e3c09274d69771bb93b22c00a8151a0403"
 dependencies = [
  "either",
  "filetime",
  "libipld",
- "multihash 0.11.4",
  "quick-protobuf",
- "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2611,7 +2609,7 @@ dependencies = [
  "libipld-macro",
  "libipld-pb",
  "log",
- "multihash 0.14.0",
+ "multihash",
  "parking_lot",
  "thiserror",
 ]
@@ -2648,7 +2646,7 @@ dependencies = [
  "anyhow",
  "cid",
  "multibase 0.9.1",
- "multihash 0.14.0",
+ "multihash",
  "thiserror",
 ]
 
@@ -2660,7 +2658,7 @@ checksum = "3cf3a6d0e65a5b3f48774f99951d063bc28f7fd799be0a3891de4b10939434e3"
 dependencies = [
  "base64 0.13.0",
  "libipld-core",
- "multihash 0.14.0",
+ "multihash",
  "serde",
  "serde_json",
 ]
@@ -2742,7 +2740,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multiaddr",
- "multihash 0.14.0",
+ "multihash",
  "multistream-select",
  "parking_lot",
  "pin-project 1.0.8",
@@ -2754,7 +2752,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "void",
  "zeroize",
 ]
@@ -2824,7 +2822,7 @@ dependencies = [
  "regex",
  "sha2 0.9.8",
  "smallvec",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
@@ -2865,7 +2863,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec",
  "uint",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -2906,7 +2904,7 @@ dependencies = [
  "parking_lot",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2959,7 +2957,7 @@ dependencies = [
  "log",
  "prost 0.8.0",
  "prost-build 0.8.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "void",
 ]
 
@@ -2995,7 +2993,7 @@ dependencies = [
  "prost-build 0.8.0",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -3016,7 +3014,7 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
@@ -3375,11 +3373,11 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash 0.14.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -3407,21 +3405,6 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "digest 0.9.0",
- "sha-1 0.9.8",
- "sha2 0.9.8",
- "sha3",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "multihash"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
@@ -3434,7 +3417,7 @@ dependencies = [
  "multihash-derive",
  "sha2 0.9.8",
  "sha3",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3468,7 +3451,7 @@ dependencies = [
  "log",
  "pin-project 1.0.8",
  "smallvec",
- "unsigned-varint 0.7.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5712,12 +5695,6 @@ dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.1",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "ipfs"
 version = "0.2.1"
-source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ipfs-bitswap"
 version = "0.1.0"
-source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
 dependencies = [
  "fnv",
  "futures",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ipfs-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/cobward/rust-ipfs?branch=kepler-staging#b177a12961cb093d394536a55f8436ef4bda8fca"
+source = "git+https://github.com/spruceid/rust-ipfs?branch=kepler-staging#07d292f9e2e10f70cfac100d665ddeddf1e6fd53"
 dependencies = [
  "either",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 didkit = "0.3"
 ethers-core = "0.6"
 hex = "0.4"
-ipfs = { git = "https://github.com/spruceid/rust-ipfs", branch = "kepler-staging" }
+ipfs = { git = "https://github.com/cobward/rust-ipfs", branch = "kepler-staging" }
 libipld = "0.12"
 libp2p = "0.39"
 nom = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 didkit = "0.3"
 ethers-core = "0.6"
 hex = "0.4"
-ipfs = { git = "https://github.com/spruceid/rust-ipfs", branch = "feat/libipld"}
+ipfs = { git = "https://github.com/spruceid/rust-ipfs", branch = "kepler-staging" }
 libipld = "0.12"
 libp2p = "0.39"
 nom = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 didkit = "0.3"
 ethers-core = "0.6"
 hex = "0.4"
-ipfs = { git = "https://github.com/cobward/rust-ipfs", branch = "kepler-staging" }
+ipfs = { git = "https://github.com/spruceid/rust-ipfs", branch = "kepler-staging" }
 libipld = "0.12"
 libp2p = "0.39"
 nom = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,33 +9,34 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ipfs-embed = { git = "https://github.com/spruceid/ipfs-embed", branch = "feat/p2pcircuit-v1", default-features = false, features = ["tokio"] }
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
 anyhow = "1.0"
+async-recursion = "0.3"
+base64 = "0.13"
+bincode = "1.3"
+bs58 = "0.4"
+cached = "0.26"
+chrono = "0.4"
 didkit = "0.3"
+ethers-core = "0.6"
+hex = "0.4"
+ipfs = { git = "https://github.com/spruceid/rust-ipfs", branch = "feat/libipld"}
+libipld = "0.12"
+libp2p = "0.39"
+nom = "6"
+reqwest = { version = "0.11", features = ["json"] }
+rocket = { version = "0.5.0-rc.1", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_with = { version = "1", features = ["hex"] }
+siwe = { git = "https://github.com/spruceid/siwe-rs" }
+sled = "0.34"
 ssi = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
-nom = "6"
-bs58 = "0.4"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1", features = ["hex"] }
-hex = "0.4"
-libipld = "0.12"
 tokio-stream = { version = "0.1", features = ["fs"] }
-cached = "0.26"
-base64 = "0.13"
-reqwest = { version = "0.11", features = ["json"] }
-chrono = "0.4"
+tokio-util = "0.6.9"
 tracing = "0.1"
-bincode = "1.3"
-sled = "0.34"
-async-recursion = "0.3"
-libp2p = "0.39"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
-siwe = "0.1"
-ethers-core = "0.6"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,14 @@ serde_with = { version = "1", features = ["hex"] }
 siwe = { git = "https://github.com/spruceid/siwe-rs" }
 sled = "0.34"
 ssi = "0.3"
+thiserror = "1"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
 tokio-util = "0.6.9"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 urlencoding = "2.1"
+void = "1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/allow_list.rs
+++ b/src/allow_list.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
-use ipfs_embed::Cid;
-use libipld::multibase::Base;
+use libipld::{cid::Cid, multibase::Base};
 use reqwest::get;
 use serde::{Deserialize, Serialize};
 use ssi::did::DIDURL;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -150,7 +150,10 @@ impl<'r> FromRequest<'r> for CreateAuthWrapper {
             Ok(i) => i,
             Err(o) => return o,
         };
-        let keys = match req.rocket().state::<RwLock<HashMap<PeerId, Ed25519Keypair>>>() {
+        let keys = match req
+            .rocket()
+            .state::<RwLock<HashMap<PeerId, Ed25519Keypair>>>()
+        {
             Some(k) => k,
             _ => {
                 return Outcome::Failure((

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,8 +3,9 @@ use crate::config;
 use crate::orbit::{create_orbit, get_metadata, load_orbit, AuthTokens, Orbit};
 use crate::relay::RelayNode;
 use anyhow::Result;
-use ipfs_embed::{Keypair, Multiaddr, PeerId};
+use ipfs::{Multiaddr, PeerId};
 use libipld::cid::Cid;
+use libp2p::identity::ed25519::Keypair as Ed25519Keypair;
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},
@@ -149,7 +150,7 @@ impl<'r> FromRequest<'r> for CreateAuthWrapper {
             Ok(i) => i,
             Err(o) => return o,
         };
-        let keys = match req.rocket().state::<RwLock<HashMap<PeerId, Keypair>>>() {
+        let keys = match req.rocket().state::<RwLock<HashMap<PeerId, Ed25519Keypair>>>() {
             Some(k) => k,
             _ => {
                 return Outcome::Failure((

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -8,14 +8,10 @@ use anyhow::Result;
 use ipfs::{
     multiaddr,
     p2p::{transport::TransportBuilder, TSwarm},
-    path::PathRoot,
-    Ipfs as OIpfs, IpfsOptions, IpfsPath, Keypair, PeerId, PinMode, Types, UninitializedIpfs,
+    Ipfs as OIpfs, IpfsOptions, Keypair, PeerId, PinMode, Types, UninitializedIpfs,
 };
 use libipld::{
-    block::Block as OBlock,
-    cid::Cid,
-    store::{DefaultParams, StoreParams},
-    Ipld,
+    block::Block as OBlock, cid::Cid, multihash::Code, raw::RawCodec, store::DefaultParams,
 };
 use libp2p::{core::transport::MemoryTransport, futures::TryStreamExt};
 
@@ -82,41 +78,21 @@ where
 impl ContentAddressedStorage for Ipfs {
     type Error = anyhow::Error;
     async fn put(&self, content: &[u8], _codec: SupportedCodecs) -> Result<Cid, Self::Error> {
-        let parts: Vec<Ipld> = content
-            .chunks(KeplerParams::MAX_BLOCK_SIZE)
-            .map(Vec::from)
-            .map(Ipld::Bytes)
-            .collect();
-
-        let dag = Ipld::List(parts);
-        let cid = self.put_dag(dag).await?;
-        self.insert_pin(&cid, true).await?;
+        // TODO find a way to stream this better? (use .take with max block size?)
+        let block: Block = Block::encode(RawCodec, Code::Blake3_256, content)?;
+        let cid = self.put_block(block).await?;
+        self.insert_pin(&cid, false).await?;
         Ok(cid)
     }
     async fn get(&self, address: &Cid) -> Result<Option<Vec<u8>>, Self::Error> {
         // TODO this api returns Result<Block, anyhow::Error>, with an err thrown for no block found
         // until this API changes (a breaking change), we will error here when no block found
-        if let Ipld::List(parts) = self
-            .get_dag(IpfsPath::new(PathRoot::Ipld(*address)))
-            .await?
-        {
-            return Ok(Some(parts.into_iter().try_fold(
-                vec![],
-                |mut acc, ipld| {
-                    if let Ipld::Bytes(mut part) = ipld {
-                        acc.append(&mut part);
-                        return Ok(acc);
-                    }
-                    Err(anyhow!("unexpected structure"))
-                },
-            )?));
-        }
-        Err(anyhow!("unexpected structure"))
+        Ok(Some(self.get_block(address).await?.data().to_vec()))
     }
 
     async fn delete(&self, address: &Cid) -> Result<(), Self::Error> {
         // TODO: does not recursively remove blocks, some cleanup will need to happen.
-        self.remove_pin(address, true).await?;
+        self.remove_pin(address, false).await?;
         self.remove_block(*address).await?;
         Ok(())
     }

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,15 +1,32 @@
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    sync::mpsc::Receiver,
+};
+
+use crate::s3::behaviour::{Behaviour, Event as BehaviourEvent};
+
 use super::cas::ContentAddressedStorage;
 use super::codec::SupportedCodecs;
-//use ipfs_embed::{DefaultParams, Ipfs as OIpfs};
-use ipfs::{Ipfs as OIpfs, Types, IpfsPath, path::PathRoot, PinMode, p2p::TSwarm};
+use anyhow::Result;
+use ipfs::{
+    multiaddr,
+    p2p::{transport::TransportBuilder, TSwarm},
+    path::PathRoot,
+    Ipfs as OIpfs, IpfsOptions, IpfsPath, Keypair, PeerId, PinMode, RepoTypes, Types,
+    UninitializedIpfs,
+};
 use libipld::{
-    Ipld,
     block::Block as OBlock,
     cid::{multihash::Code, Cid},
     raw::RawCodec,
-    store::{DefaultParams, StoreParams}
+    store::{DefaultParams, StoreParams},
+    Ipld,
 };
-use libp2p::futures::{StreamExt, TryStreamExt};
+use libp2p::{
+    core::transport::MemoryTransport,
+    futures::{StreamExt, TryStreamExt},
+};
 
 pub type KeplerParams = DefaultParams;
 // #[derive(Clone, Debug, Default)]
@@ -25,19 +42,62 @@ pub type Ipfs = OIpfs<Types>;
 pub type Block = OBlock<KeplerParams>;
 pub type Swarm = TSwarm<Types>;
 
+pub async fn create_ipfs<'l, I>(
+    id: String,
+    dir: &'l Path,
+    keypair: Keypair,
+    allowed_peers: I,
+) -> Result<(Ipfs, impl Future<Output = ()>, Receiver<BehaviourEvent>)>
+where
+    I: IntoIterator<Item = PeerId> + 'static,
+{
+    let ipfs_path = dir.join("ipfs");
+    std::fs::create_dir(&ipfs_path)?;
+    let ipfs_opts = IpfsOptions {
+        ipfs_path,
+        keypair,
+        bootstrap: vec![],
+        mdns: false,
+        kad_protocol: Some("/ipfs/lan/kad/1.0.0".to_string()),
+        listening_addrs: vec![multiaddr!(P2pCircuit)],
+        span: None,
+    };
+
+    let (sender, receiver) = std::sync::mpsc::sync_channel::<BehaviourEvent>(100);
+    let behaviour = Behaviour::new(sender);
+
+    let (transport_builder, relay_behaviour) = TransportBuilder::new(ipfs_opts.keypair.clone())?
+        .or(MemoryTransport::default())
+        .relay();
+
+    let transport = transport_builder
+        .map_auth()
+        .map(crate::transport::auth_mapper(allowed_peers))
+        .build();
+
+    let (ipfs, ipfs_task) =
+        UninitializedIpfs::<Types>::new(ipfs_opts, transport, Some(relay_behaviour))
+            .with_extended_behaviour(behaviour)
+            .start()
+            .await?;
+
+    Ok((ipfs, ipfs_task, receiver))
+}
+
 struct Content {
-    parts: Vec<Cid>
+    parts: Vec<Cid>,
 }
 
 #[rocket::async_trait]
 impl ContentAddressedStorage for Ipfs {
     type Error = anyhow::Error;
     async fn put(&self, content: &[u8], _codec: SupportedCodecs) -> Result<Cid, Self::Error> {
-        let parts: Vec<Ipld> = content.chunks(KeplerParams::MAX_BLOCK_SIZE)
+        let parts: Vec<Ipld> = content
+            .chunks(KeplerParams::MAX_BLOCK_SIZE)
             .map(Vec::from)
             .map(Ipld::Bytes)
             .collect();
-        
+
         let dag = Ipld::List(parts);
         let cid = self.put_dag(dag).await?;
         self.insert_pin(&cid, true).await?;
@@ -46,16 +106,21 @@ impl ContentAddressedStorage for Ipfs {
     async fn get(&self, address: &Cid) -> Result<Option<Vec<u8>>, Self::Error> {
         // TODO this api returns Result<Block, anyhow::Error>, with an err thrown for no block found
         // until this API changes (a breaking change), we will error here when no block found
-        if let Ipld::List(parts) = self.get_dag(IpfsPath::new(PathRoot::Ipld(address.clone()))).await? {
-        return Ok(Some(parts.into_iter()
-            .try_fold(vec![], |mut acc, ipld| {
-                if let Ipld::Bytes(mut part) = ipld {
-                    acc.append(&mut part);
-                    return Ok(acc)
-                }
-                Err(anyhow!("unexpected structure"))
-            })?))
-        } 
+        if let Ipld::List(parts) = self
+            .get_dag(IpfsPath::new(PathRoot::Ipld(address.clone())))
+            .await?
+        {
+            return Ok(Some(parts.into_iter().try_fold(
+                vec![],
+                |mut acc, ipld| {
+                    if let Ipld::Bytes(mut part) = ipld {
+                        acc.append(&mut part);
+                        return Ok(acc);
+                    }
+                    Err(anyhow!("unexpected structure"))
+                },
+            )?));
+        }
         Err(anyhow!("unexpected structure"))
     }
 
@@ -67,6 +132,10 @@ impl ContentAddressedStorage for Ipfs {
     }
     async fn list(&self) -> Result<Vec<Cid>, Self::Error> {
         // return a list of all CIDs which are aliased/pinned
-        self.list_pins(Some(PinMode::Recursive)).await.map_ok(|(cid, _pin_mode)| cid).try_collect().await
+        self.list_pins(Some(PinMode::Recursive))
+            .await
+            .map_ok(|(cid, _pin_mode)| cid)
+            .try_collect()
+            .await
     }
 }

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -44,7 +44,7 @@ where
 {
     let ipfs_path = dir.join("ipfs");
     if !ipfs_path.exists() {
-        tokio::fs::create_dir(&ipfs_path).await?;
+        tokio::fs::create_dir_all(&ipfs_path).await?;
     }
     id.insert_str(0, "/kepler/");
     let ipfs_opts = IpfsOptions {

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, path::Path, sync::{mpsc::Receiver, atomic::{AtomicU16, Ordering}}};
+use std::{future::Future, path::Path, sync::mpsc::Receiver};
 
 use crate::s3::behaviour::{Behaviour, Event as BehaviourEvent};
 
@@ -33,8 +33,6 @@ pub type Ipfs = OIpfs<Types>;
 pub type Block = OBlock<KeplerParams>;
 pub type Swarm = TSwarm<Types>;
 
-static p: AtomicU16 = AtomicU16::new(10002);
-
 pub async fn create_ipfs<'l, I>(
     id: String,
     dir: &'l Path,
@@ -46,14 +44,13 @@ where
 {
     let ipfs_path = dir.join("ipfs");
     std::fs::create_dir(&ipfs_path)?;
-    let i = p.fetch_add(1, Ordering::SeqCst);
     let ipfs_opts = IpfsOptions {
         ipfs_path,
         keypair,
         bootstrap: vec![],
         mdns: false,
         kad_protocol: None,
-        listening_addrs: vec![multiaddr!(P2pCircuit), multiaddr!(Memory(i))],
+        listening_addrs: vec![multiaddr!(P2pCircuit)],
         span: None,
     };
 
@@ -80,9 +77,7 @@ where
 
 pub async fn relay(port: u16) -> OIpfs<ipfs::TestTypes> {
     let mut ipfs_opts = IpfsOptions::inmemory_with_generated_keys();
-    ipfs_opts.listening_addrs = vec![
-        multiaddr!(Memory(port)),
-    ];
+    ipfs_opts.listening_addrs = vec![multiaddr!(Memory(port))];
 
     let (transport_builder, relay_behaviour) = TransportBuilder::new(ipfs_opts.keypair.clone())
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,15 @@ pub mod relay;
 pub mod routes;
 pub mod s3;
 pub mod siwe;
+pub mod transport;
 pub mod tz;
 pub mod tz_orbit;
 pub mod zcap;
 
-use libp2p::{PeerId, identity::{Keypair, ed25519::Keypair as Ed25519Keypair}};
+use libp2p::{
+    identity::{ed25519::Keypair as Ed25519Keypair, Keypair},
+    PeerId,
+};
 use relay::RelayNode;
 use routes::core::{
     batch_put_content, cors, delete_content, get_content, get_content_no_auth, list_content,
@@ -51,13 +55,14 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         ));
     }
 
-    let kp: Ed25519Keypair = if let Ok(mut bytes) = fs::read(kepler_config.database.path.join("kp")).await {
-        Ed25519Keypair::decode(&mut bytes)?
-    } else {
-        let kp = Ed25519Keypair::generate();
-        fs::write(kepler_config.database.path.join("kp"), kp.encode()).await?;
-        kp
-    };
+    let kp: Ed25519Keypair =
+        if let Ok(mut bytes) = fs::read(kepler_config.database.path.join("kp")).await {
+            Ed25519Keypair::decode(&mut bytes)?
+        } else {
+            let kp = Ed25519Keypair::generate();
+            fs::write(kepler_config.database.path.join("kp"), kp.encode()).await?;
+            kp
+        };
 
     let relay_node = RelayNode::new(kepler_config.relay.port, Keypair::Ed25519(kp))?;
 
@@ -157,11 +162,4 @@ Content-Type: application/json
         .await;
 
     assert!(res.status().class().is_success());
-}
-
-mod test {
-    use super::ipfs::Ipfs;
-    pub fn create_test_ipfs() -> Ipfs {
-        unimplemented!()
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
             kp
         };
 
-    let relay_node = RelayNode::new(kepler_config.relay.port, Keypair::Ed25519(kp))?;
+    let relay_node = RelayNode::new(kepler_config.relay.port, Keypair::Ed25519(kp)).await?;
 
     let mut routes = routes![
         put_content,

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -166,8 +166,8 @@ impl<T> Deref for AbortOnDrop<T> {
 
 #[derive(Clone, Debug)]
 struct OrbitTasks {
-    ipfs: Arc<AbortOnDrop<()>>,
-    behaviour_process: BehaviourProcess,
+    _ipfs: Arc<AbortOnDrop<()>>,
+    _behaviour_process: BehaviourProcess,
 }
 
 impl OrbitTasks {
@@ -177,8 +177,8 @@ impl OrbitTasks {
     ) -> Self {
         let ipfs = Arc::new(AbortOnDrop::new(tokio::spawn(ipfs_future)));
         Self {
-            ipfs,
-            behaviour_process,
+            _ipfs: ipfs,
+            _behaviour_process: behaviour_process,
         }
     }
 }
@@ -187,7 +187,7 @@ impl OrbitTasks {
 pub struct Orbit {
     pub service: Service,
     metadata: OrbitMetadata,
-    tasks: OrbitTasks,
+    _tasks: OrbitTasks,
 }
 
 fn get_params_vm(method: &str, params: &Map<String, String>) -> Option<DIDURL> {
@@ -328,7 +328,7 @@ async fn load_orbit_(dir: PathBuf, relay: (PeerId, Multiaddr)) -> Result<Orbit> 
     Ok(Orbit {
         service,
         metadata: md,
-        tasks,
+        _tasks: tasks,
     })
 }
 

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -4,28 +4,22 @@ use crate::{
     codec::SupportedCodecs,
     config::ExternalApis,
     ipfs::create_ipfs,
-    s3::{
-        behaviour::{Behaviour, BehaviourProcess, Event as BehaviourEvent},
-        Service, Store,
-    },
+    s3::{behaviour::BehaviourProcess, Service, Store},
     siwe::{SIWETokens, SIWEZcapTokens},
     tz::TezosAuthorizationString,
     tz_orbit::params_to_tz_orbit,
     zcap::ZCAPTokens,
 };
 use anyhow::{anyhow, Result};
-use ipfs::{
-    p2p::transport::TransportBuilder, IpfsOptions, MultiaddrWithoutPeerId, UninitializedIpfs,
-};
+use ipfs::MultiaddrWithoutPeerId;
 use libipld::cid::{
     multibase::Base,
     multihash::{Code, MultihashDigest},
     Cid,
 };
 use libp2p::{
-    core::{transport::MemoryTransport, Multiaddr},
+    core::Multiaddr,
     identity::{ed25519::Keypair as Ed25519Keypair, Keypair},
-    multiaddr::multiaddr,
     PeerId,
 };
 use rocket::{

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -102,7 +102,7 @@ impl Drop for RelayNode {
 mod test {
     use super::*;
     use ipfs::{
-        p2p::transport::TransportBuilder, IpfsOptions, MultiaddrWithoutPeerId, TestTypes, Types,
+        p2p::transport::TransportBuilder, IpfsOptions, MultiaddrWithoutPeerId, Types,
         UninitializedIpfs,
     };
     use libp2p::core::multiaddr::{multiaddr, Protocol};
@@ -119,7 +119,7 @@ mod test {
         let bob_path = dir.path().join("bob");
         std::fs::create_dir(&bob_path)?;
 
-        // Isn't actually in-memory, just uses std::env::tmp_dir. Does provide fine defaults for the other fields though.
+        // Isn't actually in-memory, just provides useful defaults.
         let mut alice_opts = IpfsOptions::inmemory_with_generated_keys();
         alice_opts.ipfs_path = alice_path;
         alice_opts.listening_addrs = vec![multiaddr!(P2pCircuit)];
@@ -167,8 +167,6 @@ mod test {
         )
         .await
         .expect("bob failed to connect to alice");
-
-        bob.pubsub_subscribe("test".to_string()).await?;
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -10,10 +10,11 @@ use libp2p::{
     dns::TokioDnsConfig as DnsConfig,
     mplex::MplexConfig,
     noise::{self, NoiseConfig, X25519Spec},
-    relay::new_transport_and_behaviour,
-    swarm::Swarm,
+    relay::{new_transport_and_behaviour, Relay},
+    swarm::{Swarm, NetworkBehaviourEventProcess},
     tcp::TokioTcpConfig as TcpConfig,
     yamux::YamuxConfig,
+    ping::{Ping, PingEvent},
 };
 use rocket::{
     futures::stream::StreamExt,
@@ -27,12 +28,29 @@ pub struct RelayNode {
     task: JoinHandle<()>,
 }
 
+#[derive(libp2p::NetworkBehaviour)]
+struct RelayBehaviour {
+    relay: Relay,
+    ping: Ping,
+}
+
+impl NetworkBehaviourEventProcess<()> for RelayBehaviour {
+    fn inject_event(&mut self, _event: ()) {}
+}
+impl NetworkBehaviourEventProcess<PingEvent> for RelayBehaviour {
+    fn inject_event(&mut self, _event: PingEvent) {}
+}
+
 impl RelayNode {
     pub fn new(port: u16, key: Keypair) -> Result<Self> {
         let local_public_key = key.public();
         let id = local_public_key.into_peer_id();
         let base = MemoryTransport.or_transport(DnsConfig::system(TcpConfig::new().nodelay(true))?);
         let (t, r) = new_transport_and_behaviour(Default::default(), base);
+        let b = RelayBehaviour {
+            relay: r,
+            ping: Ping::default()
+        };
 
         let transport = t
             .upgrade(Version::V1)
@@ -49,7 +67,7 @@ impl RelayNode {
 
         let relay_tcp_addr = multiaddr!(Ip4([127, 0, 0, 1]), Tcp(port));
         let relay_mem_addr = multiaddr!(Memory(port));
-        let mut swarm = Swarm::new(transport, r, id);
+        let mut swarm = Swarm::new(transport, b, id);
 
         tracing::debug!(
             "opened relay: {} at {}, {}",
@@ -83,46 +101,47 @@ impl Drop for RelayNode {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ipfs::Ipfs;
-    //use ipfs_embed::{generate_keypair, Config, ToLibp2p};
+    use ipfs::{IpfsOptions, UninitializedIpfs, TestTypes, MultiaddrWithPeerId, MultiaddrWithoutPeerId};
     use libp2p::core::multiaddr::{multiaddr, Protocol};
-    use std::path::Path;
-    use tempdir::TempDir;
+    use std::convert::TryFrom;
 
-    use crate::test::create_test_ipfs;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn relay() -> Result<()> {
         crate::tracing_try_init();
-        //let relay = RelayNode::new(10000, generate_keypair().to_keypair())?;
-        let tmp = TempDir::new("test")?;
+        let relay = RelayNode::new(10000, Keypair::generate_ed25519())?;
 
-        //let alice = Ipfs::new(get_cfg(tmp.path().join("alice"))).await?;
-        //let bob = Ipfs::new(get_cfg(tmp.path().join("bob"))).await?;
+        let mut alice_opts = IpfsOptions::inmemory_with_generated_keys();
+        alice_opts.listening_addrs = vec![multiaddr!(P2pCircuit)];
+        let (alice, task) = UninitializedIpfs::<TestTypes>::new(alice_opts).start().await?;
+        tokio::spawn(task);
+        let alice_peer_id = alice.identity().await?.0.into_peer_id();
 
-        let alice = create_test_ipfs();
-        let bob = create_test_ipfs();
+        let mut bob_opts = IpfsOptions::inmemory_with_generated_keys();
+        bob_opts.listening_addrs = vec![multiaddr!(Ip4([127,0,0,1]), Tcp(10001u16))];
+        let (bob, task) = UninitializedIpfs::<TestTypes>::new(bob_opts).start().await?;
+        tokio::spawn(task);
+        let bob_peer_id = bob.identity().await?.0.into_peer_id();
 
-        //alice.listen_on(multiaddr!(P2pCircuit))?.next().await;
-        //alice.dial_address(&relay.id, relay.internal());
+        alice.connect(
+            MultiaddrWithoutPeerId::try_from(relay.internal())?.with(relay.id.clone())
+        ).await.expect("alice failed to connect to relay");
 
-        //bob.listen_on(multiaddr!(Ip4([127u8, 0u8, 0u8, 1u8]), Tcp(10001u16)))?
-        //    .next()
-        //    .await;
-        //tracing::debug!("dialing alice");
-        //bob.dial_address(
-        //    &alice.local_peer_id(),
-        //    relay
-        //        .external()
-        //        .with(Protocol::P2p(relay.id.clone().into()))
-        //        .with(Protocol::P2pCircuit)
-        //        .with(Protocol::P2p(alice.local_peer_id().into())),
-        //);
 
-        //std::thread::sleep(Duration::from_millis(1000));
+        bob.connect(
+        MultiaddrWithPeerId::try_from(
+                relay.external()
+                    .with(Protocol::P2p(relay.id.clone().into()))
+                    .with(Protocol::P2pCircuit)
+                    .with(Protocol::P2p(alice_peer_id.clone().into())))?
+        ).await.expect("bob failed to connect to alice");
 
-        //assert!(alice.is_connected(&bob.local_peer_id()));
-        //assert!(bob.is_connected(&alice.local_peer_id()));
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        let alice_peers = alice.peers().await?;
+        let bob_peers = bob.peers().await?;
+        assert!(alice_peers.iter().any(|conn| conn.addr.peer_id == bob_peer_id));
+        assert!(bob_peers.iter().any(|conn| conn.addr.peer_id == alice_peer_id));
 
         Ok(())
     }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -84,47 +84,45 @@ impl Drop for RelayNode {
 mod test {
     use super::*;
     use crate::ipfs::Ipfs;
-    use ipfs_embed::{generate_keypair, Config, ToLibp2p};
+    //use ipfs_embed::{generate_keypair, Config, ToLibp2p};
     use libp2p::core::multiaddr::{multiaddr, Protocol};
     use std::path::Path;
     use tempdir::TempDir;
 
-    fn get_cfg<P: AsRef<Path>>(path: P) -> Config {
-        let mut c = Config::new(path.as_ref(), generate_keypair());
-        // ensure mdns isnt doing all the work here
-        c.network.mdns = None;
-        c
-    }
+    use crate::test::create_test_ipfs;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn relay() -> Result<()> {
         crate::tracing_try_init();
-        let relay = RelayNode::new(10000, generate_keypair().to_keypair())?;
+        //let relay = RelayNode::new(10000, generate_keypair().to_keypair())?;
         let tmp = TempDir::new("test")?;
 
-        let alice = Ipfs::new(get_cfg(tmp.path().join("alice"))).await?;
-        let bob = Ipfs::new(get_cfg(tmp.path().join("bob"))).await?;
+        //let alice = Ipfs::new(get_cfg(tmp.path().join("alice"))).await?;
+        //let bob = Ipfs::new(get_cfg(tmp.path().join("bob"))).await?;
 
-        alice.listen_on(multiaddr!(P2pCircuit))?.next().await;
-        alice.dial_address(&relay.id, relay.internal());
+        let alice = create_test_ipfs();
+        let bob = create_test_ipfs();
 
-        bob.listen_on(multiaddr!(Ip4([127u8, 0u8, 0u8, 1u8]), Tcp(10001u16)))?
-            .next()
-            .await;
-        tracing::debug!("dialing alice");
-        bob.dial_address(
-            &alice.local_peer_id(),
-            relay
-                .external()
-                .with(Protocol::P2p(relay.id.into()))
-                .with(Protocol::P2pCircuit)
-                .with(Protocol::P2p(alice.local_peer_id().into())),
-        );
+        //alice.listen_on(multiaddr!(P2pCircuit))?.next().await;
+        //alice.dial_address(&relay.id, relay.internal());
 
-        std::thread::sleep(Duration::from_millis(1000));
+        //bob.listen_on(multiaddr!(Ip4([127u8, 0u8, 0u8, 1u8]), Tcp(10001u16)))?
+        //    .next()
+        //    .await;
+        //tracing::debug!("dialing alice");
+        //bob.dial_address(
+        //    &alice.local_peer_id(),
+        //    relay
+        //        .external()
+        //        .with(Protocol::P2p(relay.id.clone().into()))
+        //        .with(Protocol::P2pCircuit)
+        //        .with(Protocol::P2p(alice.local_peer_id().into())),
+        //);
 
-        assert!(alice.is_connected(&bob.local_peer_id()));
-        assert!(bob.is_connected(&alice.local_peer_id()));
+        //std::thread::sleep(Duration::from_millis(1000));
+
+        //assert!(alice.is_connected(&bob.local_peer_id()));
+        //assert!(bob.is_connected(&alice.local_peer_id()));
 
         Ok(())
     }

--- a/src/routes/s3.rs
+++ b/src/routes/s3.rs
@@ -247,6 +247,7 @@ pub async fn delete_content(
     Ok(orbit
         .0
         .service
-        .index(add, vec![(k, None)]).await
+        .index(add, vec![(k, None)])
+        .await
         .map_err(|_| (Status::InternalServerError, "Failed to delete content"))?)
 }

--- a/src/s3/behaviour.rs
+++ b/src/s3/behaviour.rs
@@ -44,8 +44,8 @@ impl NetworkBehaviour for Behaviour {
         Vec::new()
     }
 
-    fn inject_connected(&mut self, peer_id: &PeerId) {
-        if let Err(_e) = self.sender.send(Event::ConnectionEstablished(peer_id.clone())) {
+    fn inject_connected(&mut self, _peer_id: &PeerId) {
+        if let Err(_e) = self.sender.send(Event::ConnectionEstablished()) {
             tracing::error!("Behaviour process has shutdown.")
         }
     }
@@ -74,8 +74,7 @@ impl BehaviourProcess {
             {
                 receiver = returned_receiver;
                 match event {
-                    Event::ConnectionEstablished(peer_id) => {
-                        info!("{} connected to {}", store.ipfs.identity().await.unwrap().0.into_peer_id(), peer_id);
+                    Event::ConnectionEstablished() => {
                         if let Err(e) = store.request_heads().await {
                             tracing::error!("failed to request heads from peers: {}", e)
                         }
@@ -88,5 +87,5 @@ impl BehaviourProcess {
 
 #[derive(Clone, Debug)]
 pub enum Event {
-    ConnectionEstablished(PeerId),
+    ConnectionEstablished(),
 }

--- a/src/s3/behaviour.rs
+++ b/src/s3/behaviour.rs
@@ -44,13 +44,17 @@ impl NetworkBehaviour for Behaviour {
         Vec::new()
     }
 
-    fn inject_connected(&mut self, _peer_id: &PeerId) {
-        if let Err(_e) = self.sender.send(Event::ConnectionEstablished()) {
+    fn inject_connected(&mut self, peer_id: &PeerId) {
+        if let Err(_e) = self.sender.send(Event::ConnectionEstablished(peer_id.clone())) {
             tracing::error!("Behaviour process has shutdown.")
         }
     }
 
-    fn inject_disconnected(&mut self, _peer_id: &PeerId) {}
+    fn inject_disconnected(&mut self, peer_id: &PeerId) {
+        if let Err(_e) = self.sender.send(Event::ConnectionTerminated(peer_id.clone())) {
+            tracing::error!("Behaviour process has shutdown.")
+        }
+    }
 
     fn inject_event(&mut self, _peer_id: PeerId, _connection: ConnectionId, _event: Void) {}
 
@@ -74,9 +78,17 @@ impl BehaviourProcess {
             {
                 receiver = returned_receiver;
                 match event {
-                    Event::ConnectionEstablished() => {
+                    Event::ConnectionEstablished(peer_id) => {
+                        if let Err(e) = store.ipfs.pubsub_add_peer(peer_id).await {
+                            tracing::error!("failed to add new peer to allowed pubsub peers: {}", e)
+                        }
                         if let Err(e) = store.request_heads().await {
                             tracing::error!("failed to request heads from peers: {}", e)
+                        }
+                    }
+                    Event::ConnectionTerminated(peer_id) => {
+                        if let Err(e) = store.ipfs.pubsub_remove_peer(peer_id).await {
+                            tracing::error!("failed to remove disconnected peer from allowed pubsub peers: {}", e)
                         }
                     }
                 }
@@ -87,5 +99,6 @@ impl BehaviourProcess {
 
 #[derive(Clone, Debug)]
 pub enum Event {
-    ConnectionEstablished(),
+    ConnectionEstablished(PeerId),
+    ConnectionTerminated(PeerId),
 }

--- a/src/s3/behaviour.rs
+++ b/src/s3/behaviour.rs
@@ -44,8 +44,8 @@ impl NetworkBehaviour for Behaviour {
         Vec::new()
     }
 
-    fn inject_connected(&mut self, _peer_id: &PeerId) {
-        if let Err(_e) = self.sender.send(Event::ConnectionEstablished) {
+    fn inject_connected(&mut self, peer_id: &PeerId) {
+        if let Err(_e) = self.sender.send(Event::ConnectionEstablished(peer_id.clone())) {
             tracing::error!("Behaviour process has shutdown.")
         }
     }
@@ -74,7 +74,8 @@ impl BehaviourProcess {
             {
                 receiver = returned_receiver;
                 match event {
-                    Event::ConnectionEstablished => {
+                    Event::ConnectionEstablished(peer_id) => {
+                        info!("{} connected to {}", store.ipfs.identity().await.unwrap().0.into_peer_id(), peer_id);
                         if let Err(e) = store.request_heads().await {
                             tracing::error!("failed to request heads from peers: {}", e)
                         }
@@ -87,5 +88,5 @@ impl BehaviourProcess {
 
 #[derive(Clone, Debug)]
 pub enum Event {
-    ConnectionEstablished,
+    ConnectionEstablished(PeerId),
 }

--- a/src/s3/behaviour.rs
+++ b/src/s3/behaviour.rs
@@ -1,0 +1,91 @@
+use std::{
+    sync::{
+        mpsc::{Receiver, SyncSender},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+
+use ipfs::{Multiaddr, PeerId};
+use libp2p::{
+    core::connection::ConnectionId,
+    swarm::{
+        protocols_handler::DummyProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction,
+        PollParameters,
+    },
+};
+use void::Void;
+
+use crate::orbit::AbortOnDrop;
+
+use super::Store;
+
+#[derive(Clone, Debug)]
+pub struct Behaviour {
+    sender: SyncSender<Event>,
+}
+
+impl Behaviour {
+    pub fn new(sender: SyncSender<Event>) -> Self {
+        Self { sender }
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ProtocolsHandler = DummyProtocolsHandler;
+
+    type OutEvent = ();
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        DummyProtocolsHandler::default()
+    }
+
+    fn addresses_of_peer(&mut self, _peer_id: &PeerId) -> Vec<Multiaddr> {
+        Vec::new()
+    }
+
+    fn inject_connected(&mut self, _peer_id: &PeerId) {
+        if let Err(_e) = self.sender.send(Event::ConnectionEstablished) {
+            tracing::error!("Behaviour process has shutdown.")
+        }
+    }
+
+    fn inject_disconnected(&mut self, _peer_id: &PeerId) {}
+
+    fn inject_event(&mut self, _peer_id: PeerId, _connection: ConnectionId, _event: Void) {}
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Void, ()>> {
+        Poll::Pending
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BehaviourProcess(Arc<AbortOnDrop<()>>);
+
+impl BehaviourProcess {
+    pub fn new(store: Store, mut receiver: Receiver<Event>) -> Self {
+        Self(Arc::new(AbortOnDrop::new(tokio::spawn(async move {
+            while let Ok(Ok((event, returned_receiver))) =
+                tokio::task::spawn_blocking(move || receiver.recv().map(|ev| (ev, receiver))).await
+            {
+                receiver = returned_receiver;
+                match event {
+                    Event::ConnectionEstablished => {
+                        if let Err(e) = store.request_heads().await {
+                            tracing::error!("failed to request heads from peers: {}", e)
+                        }
+                    }
+                }
+            }
+        }))))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    ConnectionEstablished,
+}

--- a/src/s3/behaviour.rs
+++ b/src/s3/behaviour.rs
@@ -45,13 +45,13 @@ impl NetworkBehaviour for Behaviour {
     }
 
     fn inject_connected(&mut self, peer_id: &PeerId) {
-        if let Err(_e) = self.sender.send(Event::ConnectionEstablished(peer_id.clone())) {
+        if let Err(_e) = self.sender.send(Event::ConnectionEstablished(*peer_id)) {
             tracing::error!("Behaviour process has shutdown.")
         }
     }
 
     fn inject_disconnected(&mut self, peer_id: &PeerId) {
-        if let Err(_e) = self.sender.send(Event::ConnectionTerminated(peer_id.clone())) {
+        if let Err(_e) = self.sender.send(Event::ConnectionTerminated(*peer_id)) {
             tracing::error!("Behaviour process has shutdown.")
         }
     }
@@ -88,7 +88,10 @@ impl BehaviourProcess {
                     }
                     Event::ConnectionTerminated(peer_id) => {
                         if let Err(e) = store.ipfs.pubsub_remove_peer(peer_id).await {
-                            tracing::error!("failed to remove disconnected peer from allowed pubsub peers: {}", e)
+                            tracing::error!(
+                                "failed to remove disconnected peer from allowed pubsub peers: {}",
+                                e
+                            )
                         }
                     }
                 }

--- a/src/s3/entries.rs
+++ b/src/s3/entries.rs
@@ -126,12 +126,13 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn write() -> Result<(), anyhow::Error> {
         crate::tracing_try_init();
+        let tmp = tempdir::TempDir::new("test_streams")?;
         let data = vec![3u8; KeplerParams::MAX_BLOCK_SIZE * 3];
 
-        let (ipfs, task) = IpfsOptions::inmemory_with_generated_keys()
-            .create_uninitialised_ipfs()?
-            .start()
-            .await?;
+        let mut config = IpfsOptions::inmemory_with_generated_keys();
+        config.ipfs_path = tmp.path().into();
+
+        let (ipfs, task) = config.create_uninitialised_ipfs()?.start().await?;
         let _join_handle = tokio::spawn(task);
 
         let o = write_to_store(&ipfs, Cursor::new(data.clone())).await?;

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -5,6 +5,7 @@ use rocket::futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+pub mod behaviour;
 mod entries;
 mod store;
 
@@ -30,10 +31,13 @@ impl Service {
     }
 
     pub async fn start(config: Store) -> Result<Self> {
-        let events = config.ipfs.pubsub_subscribe(config.id.clone()).await?
+        let events = config
+            .ipfs
+            .pubsub_subscribe(config.id.clone())
+            .await?
             .map(|msg| match bincode::deserialize(&msg.data) {
                 Ok(kv_msg) => Ok((msg.source, kv_msg)),
-                Err(e) => Err(anyhow!(e))
+                Err(e) => Err(anyhow!(e)),
             });
         config.request_heads().await?;
         Ok(Service::new(
@@ -125,47 +129,53 @@ async fn kv_task(events: impl Stream<Item = Result<(PeerId, KVMessage)>> + Send,
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::tracing_try_init;
-    use crate::test::create_test_ipfs;
-    //use ipfs_embed::{generate_keypair, Config, Event as SwarmEvent, Ipfs};
-    use rocket::futures::StreamExt;
-    use std::{collections::BTreeMap, time::Duration};
+    use ipfs::{Keypair, MultiaddrWithoutPeerId, Protocol};
 
-    async fn create_store(id: &str, path: std::path::PathBuf) -> Result<Store, anyhow::Error> {
-        std::fs::create_dir_all(&path)?;
-        //let mut config = Config::new(&path, generate_keypair());
-        //config.network.broadcast = None;
-        let ipfs = create_test_ipfs();
-        //ipfs.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?.next().await;
-        //let task_ipfs = ipfs.clone();
-        //tokio::spawn(async move {
-        //    let mut events = task_ipfs.swarm_events();
-        //    loop {
-        //        match events.next().await {
-        //            Some(SwarmEvent::Discovered(p)) => {
-        //                tracing::debug!("dialing peer {}", p);
-        //                task_ipfs.dial(&p);
-        //            }
-        //            None => return,
-        //            _ => continue,
-        //        }
-        //    }
-        //});
-        Store::new(id.to_string(), ipfs, sled::open(path.join("db.sled"))?)
+    use super::*;
+    use crate::{ipfs::create_ipfs, relay::RelayNode, tracing_try_init};
+    use std::{collections::BTreeMap, convert::TryFrom, path::PathBuf, time::Duration};
+
+    async fn create_store<I>(
+        id: &str,
+        path: PathBuf,
+        keypair: Keypair,
+        allowed_peers: I,
+    ) -> Result<Store, anyhow::Error>
+    where
+        I: IntoIterator<Item = PeerId> + 'static,
+    {
+        std::fs::create_dir(path.clone())?;
+        let (ipfs, ipfs_task, _receiver) =
+            create_ipfs(id.to_string(), &path, keypair, allowed_peers).await?;
+        let db = sled::open(path.join("db.sled"))?;
+        tokio::spawn(ipfs_task);
+        Store::new(id.to_string(), ipfs, db)
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test() -> Result<(), anyhow::Error> {
         tracing_try_init();
+        let relay_keypair = Keypair::generate_ed25519();
+        let relay_peer_id = relay_keypair.public().into_peer_id();
+        let relay = RelayNode::new(10001, relay_keypair)?;
+
         let tmp = tempdir::TempDir::new("test_streams")?;
         let id = "test_id".to_string();
 
-        let alice = create_store(&id, tmp.path().join("alice")).await?;
-        let bob = create_store(&id, tmp.path().join("bob")).await?;
+        let alice_keypair = Keypair::generate_ed25519();
+        let alice_peer_id = alice_keypair.public().into_peer_id();
+        let bob_keypair = Keypair::generate_ed25519();
+        let bob_peer_id = bob_keypair.public().into_peer_id();
 
+        let alice =
+            create_store(&id, tmp.path().join("alice"), alice_keypair, [bob_peer_id]).await?;
+        let bob = create_store(&id, tmp.path().join("bob"), bob_keypair, [alice_peer_id]).await?;
+
+        println!("1");
         let alice_service = alice.start_service().await?;
+        println!("2");
         let bob_service = bob.start_service().await?;
+        println!("3");
         std::thread::sleep(Duration::from_millis(500));
 
         let json = r#"{"hello":"there"}"#;
@@ -177,58 +187,89 @@ mod test {
                 .into_iter()
                 .collect();
 
+        println!("4");
         let s3_obj_1 = ObjectBuilder::new(key1.as_bytes().to_vec(), md.clone());
+        println!("5");
         let s3_obj_2 = ObjectBuilder::new(key2.as_bytes().to_vec(), md.clone());
 
+        println!("6");
         type RmItem = (Vec<u8>, Option<(u64, Cid)>);
         let rm: Vec<RmItem> = vec![];
+        println!("7");
         alice_service
             .write(vec![(s3_obj_1, json.as_bytes())], rm.clone())
             .await?;
+        println!("8");
         bob_service
             .write(vec![(s3_obj_2, json.as_bytes())], rm)
             .await?;
 
+        println!("9");
         {
             // ensure only alice has s3_obj_1
             let o = alice_service
-                .get(key1).await?
+                .get(key1)
+                .await?
                 .expect("object 1 not found for alice");
             assert_eq!(&o.key, key1.as_bytes());
             assert_eq!(&o.metadata, &md);
             assert_eq!(bob_service.get(key1).await?, None);
         };
+        println!("10");
         {
             // ensure only bob has s3_obj_2
             let o = bob_service
-                .get(key2).await?
+                .get(key2)
+                .await?
                 .expect("object 2 not found for bob");
             assert_eq!(&o.key, key2.as_bytes());
             assert_eq!(&o.metadata, &md);
             assert_eq!(alice_service.get(key2).await?, None);
         };
+        println!("11");
+
+        bob_service
+            .ipfs
+            .connect(
+                MultiaddrWithoutPeerId::try_from(
+                    relay
+                        .external()
+                        .with(Protocol::P2p(relay_peer_id.into()))
+                        .with(Protocol::P2pCircuit),
+                )?
+                .with(alice_peer_id.clone()),
+            )
+            .await?;
 
         std::thread::sleep(Duration::from_millis(500));
         assert_eq!(
             bob_service
-                .get(key1).await?
+                .get(key1)
+                .await?
                 .expect("object 1 not found for bob"),
             alice_service
-                .get(key1).await?
+                .get(key1)
+                .await?
                 .expect("object 1 not found for alice")
         );
+        println!("12");
         assert_eq!(
             bob_service
-                .get(key2).await?
+                .get(key2)
+                .await?
                 .expect("object 2 not found for bob"),
             alice_service
-                .get(key2).await?
+                .get(key2)
+                .await?
                 .expect("object 2 not found for alice")
         );
+        println!("13");
 
         // remove key1
         let add: Vec<(&[u8], Cid)> = vec![];
-        alice_service.index(add, vec![(key1.as_bytes().to_vec(), None)]).await?;
+        alice_service
+            .index(add, vec![(key1.as_bytes().to_vec(), None)])
+            .await?;
 
         assert_eq!(alice_service.get(key1).await?, None);
 

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -102,18 +102,26 @@ enum KVMessage {
 
 async fn kv_task(events: impl Stream<Item = Result<(PeerId, KVMessage)>> + Send, store: Store) {
     debug!("starting KV task");
+    let this_pid = store.ipfs.identity().await.unwrap().0.into_peer_id();
     events
         .for_each_concurrent(None, |ev| async {
             match ev {
+                Ok((p, ev)) if p == this_pid => {
+                    info!("{} filtered out this event from self: {:?}", p, ev)
+                },
                 Ok((p, KVMessage::Heads(heads))) => {
-                    debug!("new heads from {}", p);
+                    info!(
+                        "{} new heads from {}",
+                        store.ipfs.identity().await.unwrap().0.into_peer_id(),
+                        p
+                    );
                     // sync heads
                     if let Err(e) = store.try_merge_heads(heads.into_iter()).await {
                         error!("failed to merge heads {}", e);
                     };
                 }
                 Ok((p, KVMessage::StateReq)) => {
-                    debug!("{} requests state", p);
+                    info!("{} requests state", p);
                     // send heads
                     if let Err(e) = store.broadcast_heads().await {
                         error!("failed to broadcast heads {}", e);
@@ -129,7 +137,7 @@ async fn kv_task(events: impl Stream<Item = Result<(PeerId, KVMessage)>> + Send,
 
 #[cfg(test)]
 mod test {
-    use ipfs::{Keypair, MultiaddrWithoutPeerId, Protocol};
+    use ipfs::{Keypair, MultiaddrWithoutPeerId, Protocol, multiaddr};
 
     use super::*;
     use crate::{ipfs::create_ipfs, relay::RelayNode, tracing_try_init};
@@ -140,24 +148,28 @@ mod test {
         path: PathBuf,
         keypair: Keypair,
         allowed_peers: I,
-    ) -> Result<Store, anyhow::Error>
+    ) -> Result<(Store, behaviour::BehaviourProcess), anyhow::Error>
     where
         I: IntoIterator<Item = PeerId> + 'static,
     {
         std::fs::create_dir(path.clone())?;
-        let (ipfs, ipfs_task, _receiver) =
+        let (ipfs, ipfs_task, receiver) =
             create_ipfs(id.to_string(), &path, keypair, allowed_peers).await?;
         let db = sled::open(path.join("db.sled"))?;
         tokio::spawn(ipfs_task);
-        Store::new(id.to_string(), ipfs, db)
+        let store = Store::new(id.to_string(), ipfs, db)?;
+        Ok((
+            store.clone(),
+            behaviour::BehaviourProcess::new(store, receiver),
+        ))
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test() -> Result<(), anyhow::Error> {
         tracing_try_init();
-        let relay_keypair = Keypair::generate_ed25519();
-        let relay_peer_id = relay_keypair.public().into_peer_id();
-        let relay = RelayNode::new(10001, relay_keypair)?;
+        let relay = crate::ipfs::relay(10001).await;
+        let relay_peer_id = relay.identity().await?.0.into_peer_id();
+        let relay_internal = multiaddr!(Memory(10001u16));
 
         let tmp = tempdir::TempDir::new("test_streams")?;
         let id = "test_id".to_string();
@@ -167,16 +179,47 @@ mod test {
         let bob_keypair = Keypair::generate_ed25519();
         let bob_peer_id = bob_keypair.public().into_peer_id();
 
-        let alice =
+        let (alice_store, _alice_behaviour_process) =
             create_store(&id, tmp.path().join("alice"), alice_keypair, [bob_peer_id]).await?;
-        let bob = create_store(&id, tmp.path().join("bob"), bob_keypair, [alice_peer_id]).await?;
+        let (bob_store, _bob_behaviour_process) =
+            create_store(&id, tmp.path().join("bob"), bob_keypair, [bob_peer_id]).await?;
 
-        println!("1");
-        let alice_service = alice.start_service().await?;
-        println!("2");
-        let bob_service = bob.start_service().await?;
-        println!("3");
-        std::thread::sleep(Duration::from_millis(500));
+        let alice_service = alice_store.start_service().await?;
+        let bob_service = bob_store.start_service().await?;
+        //alice_service
+        //    .ipfs
+        //    .connect(
+        //        MultiaddrWithoutPeerId::try_from(relay_internal.clone())?.with(relay_peer_id.clone()),
+        //    )
+        //    .await
+        //    .expect("alice failed to connect to relay");
+        //bob_service
+        //    .ipfs
+        //    .connect(
+        //        MultiaddrWithoutPeerId::try_from(relay_internal.clone())?.with(relay_peer_id.clone()),
+        //    )
+        //    .await
+        //    .expect("bob failed to connect to relay");
+
+        bob_service
+            .ipfs
+            .connect(
+                MultiaddrWithoutPeerId::try_from(
+                    multiaddr!(Memory(10002u16))
+                    //relay_internal
+                    //    .with(Protocol::P2p(relay_peer_id.into()))
+                    //    .with(Protocol::P2pCircuit),
+                )?
+                .with(alice_peer_id.clone()),
+            )
+            .await
+            .expect("bob failed to connect to alice");
+
+        let peers = bob_service.ipfs.peers().await?;
+        tracing::info!(
+            "{:?}",
+            peers.iter().map(|c| c.addr.peer_id).collect::<Vec<_>>()
+        );
 
         let json = r#"{"hello":"there"}"#;
         let key1 = "my_json.json";
@@ -187,24 +230,18 @@ mod test {
                 .into_iter()
                 .collect();
 
-        println!("4");
         let s3_obj_1 = ObjectBuilder::new(key1.as_bytes().to_vec(), md.clone());
-        println!("5");
         let s3_obj_2 = ObjectBuilder::new(key2.as_bytes().to_vec(), md.clone());
 
-        println!("6");
         type RmItem = (Vec<u8>, Option<(u64, Cid)>);
         let rm: Vec<RmItem> = vec![];
-        println!("7");
         alice_service
             .write(vec![(s3_obj_1, json.as_bytes())], rm.clone())
             .await?;
-        println!("8");
         bob_service
             .write(vec![(s3_obj_2, json.as_bytes())], rm)
             .await?;
 
-        println!("9");
         {
             // ensure only alice has s3_obj_1
             let o = alice_service
@@ -213,9 +250,8 @@ mod test {
                 .expect("object 1 not found for alice");
             assert_eq!(&o.key, key1.as_bytes());
             assert_eq!(&o.metadata, &md);
-            assert_eq!(bob_service.get(key1).await?, None);
+            assert_eq!(bob_service.get(key1).await?, None, "object 1 found for bob");
         };
-        println!("10");
         {
             // ensure only bob has s3_obj_2
             let o = bob_service
@@ -224,24 +260,20 @@ mod test {
                 .expect("object 2 not found for bob");
             assert_eq!(&o.key, key2.as_bytes());
             assert_eq!(&o.metadata, &md);
-            assert_eq!(alice_service.get(key2).await?, None);
+            assert_eq!(
+                alice_service.get(key2).await?,
+                None,
+                "object 2 found for alice"
+            );
         };
-        println!("11");
+        let peers = bob_service.ipfs.peers().await?;
+        tracing::info!(
+            "{:#?}",
+            peers
+        );
+        tracing::info!("11");
 
-        bob_service
-            .ipfs
-            .connect(
-                MultiaddrWithoutPeerId::try_from(
-                    relay
-                        .external()
-                        .with(Protocol::P2p(relay_peer_id.into()))
-                        .with(Protocol::P2pCircuit),
-                )?
-                .with(alice_peer_id.clone()),
-            )
-            .await?;
-
-        std::thread::sleep(Duration::from_millis(500));
+        tokio::time::sleep(Duration::from_millis(500)).await;
         assert_eq!(
             bob_service
                 .get(key1)
@@ -252,7 +284,7 @@ mod test {
                 .await?
                 .expect("object 1 not found for alice")
         );
-        println!("12");
+        tracing::info!("12");
         assert_eq!(
             bob_service
                 .get(key2)
@@ -263,7 +295,7 @@ mod test {
                 .await?
                 .expect("object 2 not found for alice")
         );
-        println!("13");
+        tracing::info!("13");
 
         // remove key1
         let add: Vec<(&[u8], Cid)> = vec![];
@@ -271,11 +303,15 @@ mod test {
             .index(add, vec![(key1.as_bytes().to_vec(), None)])
             .await?;
 
-        assert_eq!(alice_service.get(key1).await?, None);
+        assert_eq!(
+            alice_service.get(key1).await?,
+            None,
+            "alice still has object 1"
+        );
 
         std::thread::sleep(Duration::from_millis(500));
 
-        assert_eq!(bob_service.get(key1).await?, None);
+        assert_eq!(bob_service.get(key1).await?, None, "bob still has object 1");
 
         Ok(())
     }

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -138,7 +138,7 @@ mod test {
     use ipfs::{Keypair, MultiaddrWithoutPeerId, Protocol};
 
     use super::*;
-    use crate::{ipfs::create_ipfs, relay::RelayNode, tracing_try_init};
+    use crate::{ipfs::create_ipfs, relay::test::test_relay, tracing_try_init};
     use std::{collections::BTreeMap, convert::TryFrom, path::PathBuf, time::Duration};
 
     async fn create_store<I>(
@@ -165,7 +165,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test() -> Result<(), anyhow::Error> {
         tracing_try_init();
-        let relay = RelayNode::new(10001, Keypair::generate_ed25519()).await?;
+        let relay = test_relay().await?;
         let relay_peer_id = relay.id.clone();
         let relay_internal = relay.internal();
 
@@ -208,7 +208,8 @@ mod test {
             .ipfs
             .connect(
                 MultiaddrWithoutPeerId::try_from(
-                    relay_internal
+                    relay
+                        .external()
                         .with(Protocol::P2p(relay_peer_id.into()))
                         .with(Protocol::P2pCircuit),
                 )?

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -185,16 +185,6 @@ mod test {
         let alice_service = alice_store.start_service().await?;
         let bob_service = bob_store.start_service().await?;
 
-        // Add peers to eachothers floodsub `target_list` of peers to share messages with.
-        bob_service
-            .ipfs
-            .pubsub_add_peer(alice_peer_id.clone())
-            .await?;
-        alice_service
-            .ipfs
-            .pubsub_add_peer(bob_peer_id.clone())
-            .await?;
-
         // Connect the peers to the relay.
         alice_service
             .ipfs

--- a/src/s3/store.rs
+++ b/src/s3/store.rs
@@ -222,7 +222,14 @@ impl Store {
     pub(crate) async fn broadcast_heads(&self) -> Result<()> {
         let (heads, height) = self.heads.state()?;
         if !heads.is_empty() {
-            info!("{}: broadcasting {} heads at maxheight {} on {}", self.ipfs.identity().await?.0.into_peer_id(), heads.len(), height, self.id);
+            info!(
+                "{}: broadcasting {} heads at maxheight {} on {}: {:?}",
+                self.ipfs.identity().await?.0.into_peer_id(),
+                heads.len(),
+                height,
+                self.id,
+                heads
+            );
             self.ipfs
                 .pubsub_publish(
                     self.id.clone(),

--- a/src/s3/store.rs
+++ b/src/s3/store.rs
@@ -222,13 +222,11 @@ impl Store {
     pub(crate) async fn broadcast_heads(&self) -> Result<()> {
         let (heads, height) = self.heads.state()?;
         if !heads.is_empty() {
-            info!(
-                "{}: broadcasting {} heads at maxheight {} on {}: {:?}",
-                self.ipfs.identity().await?.0.into_peer_id(),
+            debug!(
+                "broadcasting {} heads at maxheight {} on {}",
                 heads.len(),
                 height,
                 self.id,
-                heads
             );
             self.ipfs
                 .pubsub_publish(

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::Result;
 use didkit::DID_METHODS;
-use ipfs_embed::Cid;
+use libipld::cid::Cid;
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},
@@ -15,7 +15,7 @@ use ethers_core::{types::H160, utils::to_checksum};
 use hex::FromHex;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use siwe::eip4361::Message;
+use siwe::Message;
 use std::{ops::Deref, str::FromStr};
 
 pub struct SIWESignature([u8; 65]);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -33,6 +33,94 @@ where
 pub enum AuthError {
     #[error("`{0}`")]
     Noise(#[from] NoiseError),
-    #[error("Unauthorized: peer attempting connection is not in approved peer list.")]
+    #[error("Unauthorised: peer attempting connection is not in approved peer list.")]
     NotInList,
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use crate::{ipfs::create_ipfs, relay::test::test_relay};
+    use ipfs::{MultiaddrWithoutPeerId, Protocol};
+    use libp2p::identity::Keypair;
+    use tempdir::TempDir;
+
+    #[tokio::test]
+    async fn authorised() -> anyhow::Result<()> {
+        let id = "transport_unauthorized".to_string();
+        let temp_dir = TempDir::new(&id)?;
+        let relay = test_relay().await?;
+
+        let alice_keypair = Keypair::generate_ed25519();
+        let alice_peer_id = alice_keypair.public().into_peer_id();
+        let alice_path = temp_dir.path().join("alice");
+        let bob_keypair = Keypair::generate_ed25519();
+        let bob_peer_id = bob_keypair.public().into_peer_id();
+        let bob_path = temp_dir.path().join("bob");
+
+        let (alice, ipfs_task, _alice_behaviour_process) =
+            create_ipfs(id.clone(), &alice_path, alice_keypair, vec![bob_peer_id]).await?;
+        tokio::task::spawn(ipfs_task);
+        let (bob, ipfs_task, _bob_behaviour_process) =
+            create_ipfs(id.clone(), &bob_path, bob_keypair, vec![]).await?;
+        tokio::task::spawn(ipfs_task);
+
+        alice
+            .connect(MultiaddrWithoutPeerId::try_from(relay.internal())?.with(relay.id.clone()))
+            .await?;
+
+        bob.connect(
+            MultiaddrWithoutPeerId::try_from(
+                relay
+                    .external()
+                    .with(Protocol::P2p(relay.id.clone().into()))
+                    .with(Protocol::P2pCircuit),
+            )?
+            .with(alice_peer_id),
+        )
+        .await
+        .expect("authorised peer (bob) could not connect to alice");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unauthorised() -> anyhow::Result<()> {
+        let id = "transport_unauthorized".to_string();
+        let temp_dir = TempDir::new(&id)?;
+        let relay = test_relay().await?;
+
+        let alice_keypair = Keypair::generate_ed25519();
+        let alice_peer_id = alice_keypair.public().into_peer_id();
+        let alice_path = temp_dir.path().join("alice");
+        let bob_keypair = Keypair::generate_ed25519();
+        let _bob_peer_id = bob_keypair.public().into_peer_id();
+        let bob_path = temp_dir.path().join("bob");
+
+        let (alice, ipfs_task, _alice_behaviour_process) =
+            create_ipfs(id.clone(), &alice_path, alice_keypair, vec![]).await?;
+        tokio::task::spawn(ipfs_task);
+        let (bob, ipfs_task, _bob_behaviour_process) =
+            create_ipfs(id.clone(), &bob_path, bob_keypair, vec![]).await?;
+        tokio::task::spawn(ipfs_task);
+
+        alice
+            .connect(MultiaddrWithoutPeerId::try_from(relay.internal())?.with(relay.id.clone()))
+            .await?;
+
+        bob.connect(
+            MultiaddrWithoutPeerId::try_from(
+                relay
+                    .external()
+                    .with(Protocol::P2p(relay.id.into()))
+                    .with(Protocol::P2pCircuit),
+            )?
+            .with(alice_peer_id),
+        )
+        .await
+        .expect_err("unauthorised peer (bob) connected to alice");
+
+        Ok(())
+    }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,38 @@
+use std::{
+    collections::HashSet,
+    future::{ready, Ready},
+};
+
+use ipfs::PeerId;
+use libp2p::{core::Endpoint, noise::NoiseError};
+
+pub fn auth_mapper<A, I>(
+    i: I,
+) -> impl Clone + FnOnce(((PeerId, A), Endpoint)) -> Ready<Result<(PeerId, A), AuthError>>
+where
+    I: IntoIterator<Item = PeerId>,
+{
+    let peer_list: HashSet<PeerId> = i.into_iter().collect();
+    move |((peer_id, a), endpoint): ((PeerId, A), Endpoint)| {
+        ready({
+            match endpoint {
+                Endpoint::Dialer => Ok((peer_id, a)),
+                Endpoint::Listener => {
+                    if peer_list.contains(&peer_id) {
+                        Ok((peer_id, a))
+                    } else {
+                        Err(AuthError::NotInList)
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("`{0}`")]
+    Noise(#[from] NoiseError),
+    #[error("Unauthorized: peer attempting connection is not in approved peer list.")]
+    NotInList,
+}

--- a/src/tz_orbit.rs
+++ b/src/tz_orbit.rs
@@ -1,6 +1,6 @@
 use crate::orbit::OrbitMetadata;
 use anyhow::Result;
-use ipfs_embed::{Multiaddr, PeerId};
+use libp2p::{Multiaddr, PeerId};
 use libipld::cid::Cid;
 use reqwest;
 use serde::{de::DeserializeOwned, Deserialize};

--- a/src/tz_orbit.rs
+++ b/src/tz_orbit.rs
@@ -1,7 +1,7 @@
 use crate::orbit::OrbitMetadata;
 use anyhow::Result;
-use libp2p::{Multiaddr, PeerId};
 use libipld::cid::Cid;
+use libp2p::{Multiaddr, PeerId};
 use reqwest;
 use serde::{de::DeserializeOwned, Deserialize};
 use ssi::did::DIDURL;

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use didkit::DID_METHODS;
-use ipfs_embed::Cid;
+use libipld::Cid;
 use rocket::{
     http::Status,
     request::{FromRequest, Outcome, Request},


### PR DESCRIPTION
As above. This is based on the `kepler-staging` branch of `spruceid/rust-ipfs`, which contains a number of changes and fixes to rust-ipfs to make it usable by Kepler.

Outstanding issues (which may not be addressed by this PR):
- Replication: currently there is a race condition with connecting to a peer and then immediately writing data. There will also be further work to support peer authentication for mutable orbits.
- Garbage collection: unpinned blocks are not removed. We will need to either extend the object deletion process to clean down recursively, or else write a GC'er. This may make more sense to look into as we think more about storage backends.