### PR TITLE
Fix outstanding bugs from ipfs cutover.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
             })
         }))
         .manage(relay_node)
-        .manage(RwLock::new(HashMap::<PeerId, Keypair>::new())))
+        .manage(RwLock::new(HashMap::<PeerId, Ed25519Keypair>::new())))
 }
 
 #[test]

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -33,7 +33,6 @@ use cached::proc_macro::cached;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use ssi::did::DIDURL;
-use tokio::spawn;
 use std::{
     collections::HashMap as Map,
     convert::TryFrom,
@@ -41,6 +40,7 @@ use std::{
     path::PathBuf,
     sync::{Arc, RwLock},
 };
+use tokio::spawn;
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -171,10 +171,7 @@ struct OrbitTasks {
 }
 
 impl OrbitTasks {
-    fn new(
-        ipfs_future: JoinHandle<()>,
-        behaviour_process: BehaviourProcess,
-    ) -> Self {
+    fn new(ipfs_future: JoinHandle<()>, behaviour_process: BehaviourProcess) -> Self {
         let ipfs = Arc::new(AbortOnDrop::new(ipfs_future));
         Self {
             _ipfs: ipfs,

--- a/src/orbit.rs
+++ b/src/orbit.rs
@@ -37,7 +37,6 @@ use tokio::spawn;
 use std::{
     collections::HashMap as Map,
     convert::TryFrom,
-    future::Future,
     ops::Deref,
     path::PathBuf,
     sync::{Arc, RwLock},


### PR DESCRIPTION
- Rocket state needed updated Keypair type.
- Needed to connect to the relay from new peers immediately otherwise the S3 service setup failed.
- Needed to compare the CIDs by value from delegation and invocation, since the CIDs were being formatted as strings with different multibases.