### PR TITLE
Fix target action checking against capability and Ipfs list fn

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,6 +19,19 @@ pub trait AuthorizationToken {
     fn resource(&self) -> &ResourceId;
 }
 
+pub fn simple_check(target: &ResourceId, capability: &ResourceId) -> Result<()> {
+    check_orbit_and_service(target, capability)?;
+    simple_prefix_check(target, capability)?;
+    simple_check_fragments(target, capability)
+}
+
+pub fn simple_check_fragments(target: &ResourceId, capability: &ResourceId) -> Result<()> {
+    match (target.fragment(), capability.fragment()) {
+        (Some(t), Some(c)) if t == c => Ok(()),
+        _ => Err(anyhow!("Target Action does not match Capability")),
+    }
+}
+
 pub fn simple_prefix_check(target: &ResourceId, capability: &ResourceId) -> Result<()> {
     // if #action is same
     // Ok if target.path => cap.path

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -60,7 +60,6 @@ pub fn check_orbit_and_service(
     target: &ResourceId,
     capability: &ResourceId,
 ) -> Result<(), TargetCheckError> {
-    tracing::debug!("{} {}", target, capability);
     if target.orbit() != capability.orbit() {
         Err(TargetCheckError::IncorrectOrbit)
     } else if target.service() != capability.service() {

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -98,7 +98,7 @@ impl ContentAddressedStorage for Ipfs {
     }
     async fn list(&self) -> Result<Vec<Cid>, Self::Error> {
         // return a list of all CIDs which are aliased/pinned
-        self.list_pins(Some(PinMode::Recursive))
+        self.list_pins(Some(PinMode::Direct))
             .await
             .map_ok(|(cid, _pin_mode)| cid)
             .try_collect()

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -81,7 +81,7 @@ impl ContentAddressedStorage for Ipfs {
         // TODO find a way to stream this better? (use .take with max block size?)
         let block: Block = Block::encode(RawCodec, Code::Blake3_256, content)?;
         let cid = self.put_block(block).await?;
-        self.insert_pin(&cid, false).await?;
+        self.insert_pin(&cid, true).await?;
         Ok(cid)
     }
     async fn get(&self, address: &Cid) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -92,13 +92,13 @@ impl ContentAddressedStorage for Ipfs {
 
     async fn delete(&self, address: &Cid) -> Result<(), Self::Error> {
         // TODO: does not recursively remove blocks, some cleanup will need to happen.
-        self.remove_pin(address, false).await?;
+        self.remove_pin(address, true).await?;
         self.remove_block(*address).await?;
         Ok(())
     }
     async fn list(&self) -> Result<Vec<Cid>, Self::Error> {
         // return a list of all CIDs which are aliased/pinned
-        self.list_pins(Some(PinMode::Direct))
+        self.list_pins(Some(PinMode::Recursive))
             .await
             .map_ok(|(cid, _pin_mode)| cid)
             .try_collect()

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{check_orbit_and_service, simple_prefix_check, AuthorizationPolicy, AuthorizationToken},
+    auth::{simple_check, AuthorizationPolicy, AuthorizationToken},
     manifest::Manifest,
     resource::ResourceId,
     zcap::KeplerInvocation,
@@ -196,10 +196,7 @@ impl AuthorizationPolicy<SIWEZcapTokens> for Manifest {
             .resources
             .iter()
             .filter_map(|s| s.as_str().parse().ok())
-            .any(|r| {
-                check_orbit_and_service(target, &r).is_ok()
-                    && simple_prefix_check(target, &r).is_ok()
-            })
+            .any(|r| simple_check(target, &r).is_ok())
         {
             return Err(anyhow!("Delegation semantics violated"));
         }
@@ -260,10 +257,7 @@ impl AuthorizationPolicy<SIWETokens> for Manifest {
                     .resources
                     .iter()
                     .filter_map(|s| s.as_str().parse().ok())
-                    .any(|r| {
-                        check_orbit_and_service(&t.invoked_action, &r).is_ok()
-                            && simple_prefix_check(&t.invoked_action, &r).is_ok()
-                    })
+                    .any(|r| simple_check(&t.invoked_action, &r).is_ok())
                 {
                     return Err(anyhow!("Delegation semantics violated"));
                 };

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{check_orbit_and_service, simple_prefix_check, AuthorizationPolicy, AuthorizationToken},
+    auth::{simple_check, AuthorizationPolicy, AuthorizationToken},
     manifest::Manifest,
     resource::ResourceId,
 };
@@ -121,10 +121,12 @@ impl AuthorizationPolicy<ZCAPTokens> for Manifest {
 
                 let target = &auth_token.invocation.property_set.invocation_target;
 
-                if !d.property_set.capability_action.iter().any(|r| {
-                    check_orbit_and_service(target, r).is_ok()
-                        && simple_prefix_check(target, r).is_ok()
-                }) {
+                if !d
+                    .property_set
+                    .capability_action
+                    .iter()
+                    .any(|r| simple_check(target, r).is_ok())
+                {
                     return Err(anyhow!("Delegation semantics violated"));
                 }
 


### PR DESCRIPTION
The updated `impl AuthorisationPolicy<...>` resource checking from PR #83 was not checking that the invoked resource action was the same as the delegated resource action. This pr should correct that. This PR also fixes `Ipfs::list`, returning directly pinned blocks.