### PR TITLE
Add Docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Publish Docker
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [published, created, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and push image
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: spruceid/kepler
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_PACKAGE_PUSH_TOKEN }}
+        registry: ghcr.io
+        tag_names: true
+        tag_semver: true
+        snapshot: true


### PR DESCRIPTION
It only takes 20min https://github.com/spruceid/kepler/runs/5852970615?check_suite_focus=true :grimacing: 

I'm not really keen on adding caching for releases. But it's easy to enable, so if we add e2e that use the docker image, we can.