### PR TITLE
Fix delegated orbit creation.

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,7 +38,7 @@ pub fn simple_prefix_check(target: &ResourceId, capability: &ResourceId) -> Resu
     if target.service() == capability.service()
         && match (target.path(), capability.path()) {
             (Some(t), Some(c)) => t.starts_with(c),
-            (Some(_), None) => true,
+            (_, None) => true,
             _ => false,
         }
     {


### PR DESCRIPTION
Delegated orbit creation was failing when checking the invoked resource against the capabilities. The resource: `kepler:ens:example.eth://default#peer` does not have a path, but is a valid capability. Therefore a capability with an empty path should also allow invocations against an empty path.