### PR TITLE
Initial tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,7 +3224,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding 2.1.0",
- "uuid",
  "void",
 ]
 
@@ -6737,15 +6736,6 @@ name = "urlencoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
-
-[[package]]
-name = "uuid"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
-dependencies = [
- "getrandom 0.2.5",
-]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
  "percent-encoding",
  "pin-project 1.0.10",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -701,7 +701,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
  "aws-smithy-types",
- "rustc_version 0.4.0",
+ "rustc_version",
  "tracing",
  "zeroize",
 ]
@@ -756,7 +756,7 @@ dependencies = [
  "failure",
  "ff-zeroize",
  "hex",
- "hkdf",
+ "hkdf 0.8.0",
  "pairing-plus",
  "rand 0.7.3",
  "rayon",
@@ -1251,12 +1251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,12 +1258,19 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
+checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
+ "aes-gcm",
+ "base64 0.13.0",
+ "hkdf 0.12.3",
+ "hmac 0.12.1",
  "percent-encoding",
- "time 0.2.27",
+ "rand 0.8.5",
+ "sha2 0.10.2",
+ "subtle 2.4.1",
+ "time 0.3.9",
  "version_check",
 ]
 
@@ -1925,12 +1926,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
@@ -2618,7 +2613,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2648,6 +2643,31 @@ name = "hashbrown"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+
+[[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -2690,6 +2710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2736,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2910,6 +2948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e85a1509a128c855368e135cffcde7eac17d8e1083f41e2b98c58bc1a5074be"
+
+[[package]]
 name = "ipconfig"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,7 +2991,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
  "tracing-futures",
  "trust-dns-resolver",
@@ -3158,6 +3202,8 @@ dependencies = [
  "libipld",
  "libp2p",
  "nom 6.1.2",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "prometheus",
  "regex",
  "reqwest",
@@ -3172,10 +3218,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-log",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "urlencoding 2.1.0",
+ "uuid",
  "void",
 ]
 
@@ -3689,7 +3738,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3721,15 +3770,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
 
 [[package]]
 name = "matchers"
@@ -3851,7 +3891,7 @@ dependencies = [
  "mime",
  "spin 0.9.2",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "version_check",
 ]
 
@@ -4208,6 +4248,77 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project 1.0.10",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
+dependencies = [
+ "async-trait",
+ "headers",
+ "http",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "reqwest",
+ "thiserror",
+ "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4642,12 +4753,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -5244,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a71c18c42a0eb15bf3816831caf0dad11e7966f2a41aaf486a701979c4dd1f2"
+checksum = "98ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5262,7 +5367,7 @@ dependencies = [
  "memchr",
  "multer",
  "num_cpus",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "rand 0.8.5",
  "ref-cast",
@@ -5272,10 +5377,10 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.2.27",
+ "time 0.3.9",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.1",
  "ubyte",
  "version_check",
  "yansi",
@@ -5283,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f5fa462f7eb958bba8710c17c5d774bbbd59809fa76fb1957af7e545aea8bb"
+checksum = "d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47"
 dependencies = [
  "devise",
  "glob",
@@ -5299,19 +5404,18 @@ dependencies = [
 
 [[package]]
 name = "rocket_http"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c8b7d512d2fcac2316ebe590cde67573844b99e6cc9ee0f53375fa16e25ebd"
+checksum = "2ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2"
 dependencies = [
  "cookie",
  "either",
+ "futures",
  "http",
  "hyper",
  "indexmap",
  "log",
  "memchr",
- "mime",
- "parking_lot 0.11.2",
  "pear",
  "percent-encoding",
  "pin-project-lite",
@@ -5320,7 +5424,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.2.27",
+ "time 0.3.9",
  "tokio",
  "uncased",
 ]
@@ -5361,20 +5465,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.6",
+ "semver",
 ]
 
 [[package]]
@@ -5497,24 +5592,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequoia-openpgp"
@@ -5672,19 +5752,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.1"
+name = "sha-1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "sha1_smol",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha1collisiondetection"
@@ -5858,7 +5934,7 @@ dependencies = [
  "curve25519-dalek 4.0.0-pre.1",
  "rand_core 0.6.3",
  "ring",
- "rustc_version 0.4.0",
+ "rustc_version",
  "sha2 0.10.2",
  "subtle 2.4.1",
 ]
@@ -5951,7 +6027,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.5",
  "hex",
- "hkdf",
+ "hkdf 0.8.0",
  "http",
  "iref",
  "json",
@@ -6007,19 +6083,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "state"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf4f5369e6d3044b5e365c9690f451516ac8f0954084622b49ea3fde2f6de5"
+checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
 dependencies = [
  "loom",
 ]
@@ -6029,55 +6096,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
@@ -6210,6 +6228,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6221,51 +6261,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-keccak"
@@ -6380,6 +6390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6474,6 +6497,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6485,14 +6521,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
- "chrono",
  "lazy_static",
- "matchers 0.0.1",
+ "matchers",
  "regex",
  "serde",
  "serde_json",
@@ -6503,24 +6538,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
-dependencies = [
- "ansi_term",
- "lazy_static",
- "matchers 0.1.0",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -6720,6 +6737,15 @@ name = "urlencoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+
+[[package]]
+name = "uuid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+dependencies = [
+ "getrandom 0.2.5",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ libp2p = { default-features = false, features = ["floodsub", "identify", "kad", 
 nom = "6"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio", "reqwest_collector_client"] }
-# opentelemetry-otlp = { version = "0.10.0", features = ["rt-tokio"] }
 prometheus = { version = "0.13.0", features = ["process"] }
 regex = "1.5"
 reqwest = { version = "0.11", features = ["json"] }
@@ -53,7 +52,6 @@ tracing-log = "0.1"
 tracing-opentelemetry = "0.17.2"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 urlencoding = "2.1"
-uuid = { version = "1.0.0", features = ["v4"] }
 void = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,8 @@
 name = "kepler"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -32,10 +31,13 @@ lazy_static = "1.4.0"
 libipld = "0.12"
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.43.0" }
 nom = "6"
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio", "reqwest_collector_client"] }
+# opentelemetry-otlp = { version = "0.10.0", features = ["rt-tokio"] }
 prometheus = { version = "0.13.0", features = ["process"] }
 regex = "1.5"
 reqwest = { version = "0.11", features = ["json"] }
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "1", features = ["hex"] }
@@ -47,8 +49,11 @@ tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
 tokio-util = "0.6.9"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-log = "0.1"
+tracing-opentelemetry = "0.17.2"
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 urlencoding = "2.1"
+uuid = { version = "1.0.0", features = ["v4"] }
 void = "1"
 
 [dev-dependencies]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -225,7 +225,7 @@ impl<'l> FromRequest<'l> for InvokeAuthWrapper {
             .as_ref()
             .unwrap();
         let span = info_span!(parent: &req_span.0, "invoke_auth_wrapper");
-        // let _span_guard = span.enter();
+        // Instrumenting async block to handle yielding properly
         async move {
             let timer = crate::prometheus::AUTHORIZATION_HISTOGRAM
                 .with_label_values(&["invoke"])

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,30 @@ use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub struct Config {
+    pub log: Logging,
     pub storage: Storage,
     pub apis: ExternalApis,
     pub orbits: OrbitsConfig,
     pub relay: Relay,
     pub prometheus: Prometheus,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]
+pub struct Logging {
+    pub format: LoggingFormat,
+    pub tracing: Tracing,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+pub enum LoggingFormat {
+    Text,
+    Json,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+pub struct Tracing {
+    pub traceheader: String,
+    pub enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]
@@ -82,6 +101,21 @@ pub struct Relay {
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Prometheus {
     pub port: u16,
+}
+
+impl Default for Tracing {
+    fn default() -> Tracing {
+        Tracing {
+            enabled: false,
+            traceheader: "Spruce-Trace-Id".to_string(),
+        }
+    }
+}
+
+impl Default for LoggingFormat {
+    fn default() -> LoggingFormat {
+        LoggingFormat::Text
+    }
 }
 
 impl Default for BlockStorage {

--- a/src/kv/entries.rs
+++ b/src/kv/entries.rs
@@ -131,11 +131,11 @@ mod test {
     use ipfs::IpfsOptions;
 
     use super::*;
-    use crate::kv::DagCborCodec;
+    use crate::{config, kv::DagCborCodec, tracing::tracing_try_init};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn write() -> Result<(), anyhow::Error> {
-        crate::tracing_try_init();
+        tracing_try_init(&config::Logging::default());
         let tmp = tempdir::TempDir::new("test_streams")?;
         let data = vec![3u8; KeplerParams::MAX_BLOCK_SIZE * 3];
 

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -135,9 +135,7 @@ mod test {
     use ipfs::{Keypair, MultiaddrWithoutPeerId, Protocol};
 
     use super::*;
-    use crate::{
-        capabilities::AuthRef, config, ipfs::create_ipfs, relay::test::test_relay, tracing_try_init,
-    };
+    use crate::{capabilities::AuthRef, config, ipfs::create_ipfs, relay::test::test_relay};
     use std::{
         collections::BTreeMap, convert::TryFrom, path::PathBuf, str::FromStr, time::Duration,
     };
@@ -174,7 +172,6 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test() -> Result<(), anyhow::Error> {
-        tracing_try_init();
         let relay = test_relay().await?;
         let relay_peer_id = relay.id.clone();
         let relay_internal = relay.internal();

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -119,7 +119,7 @@ impl Store {
         })
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "kv::list", skip_all)]
     pub async fn list(&self) -> impl Iterator<Item = Result<Vec<u8>>> + '_ {
         let elements = match self.index.elements().await {
             Ok(e) => e,
@@ -147,7 +147,7 @@ impl Store {
             .into_iter()
     }
 
-    #[instrument(skip(self, name))]
+    #[instrument(name = "kv::get", skip_all)]
     pub async fn get<N: AsRef<[u8]>>(&self, name: N) -> Result<Option<Object>> {
         let key = name;
         match self.index.element(&key).await? {
@@ -165,7 +165,7 @@ impl Store {
         }
     }
 
-    #[instrument(skip(self, key))]
+    #[instrument(name = "kv::read", skip_all)]
     pub async fn read<N>(&self, key: N) -> Result<Option<(BTreeMap<String, String>, ObjectReader)>>
     where
         N: AsRef<[u8]>,
@@ -188,7 +188,7 @@ impl Store {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "kv::request_heads", skip_all)]
     pub(crate) async fn request_heads(&self) -> Result<()> {
         debug!("requesting heads");
         self.ipfs
@@ -197,7 +197,7 @@ impl Store {
         Ok(())
     }
 
-    #[instrument(skip(self, add, remove))]
+    #[instrument(name = "kv::write", skip_all)]
     pub async fn write<N, R>(
         &self,
         add: impl IntoIterator<Item = (ObjectBuilder, R)>,
@@ -222,7 +222,7 @@ impl Store {
         self.index(indexes, remove).await
     }
 
-    #[instrument(skip(self, add, remove))]
+    #[instrument(name = "kv::index", skip_all)]
     pub async fn index<N, M>(
         &self,
         // tuples of (obj-name, content cid, auth id)
@@ -271,7 +271,7 @@ impl Store {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "kv::broadcast_heads", skip_all)]
     pub(crate) async fn broadcast_heads(&self) -> Result<()> {
         let (heads, height) = self.heads.get_heads().await?;
         if !heads.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ mod tracing;
 pub mod transport;
 pub mod zcap;
 
-use ::tracing::subscriber::set_global_default;
 use libp2p::{
     identity::{ed25519::Keypair as Ed25519Keypair, Keypair},
     PeerId,
@@ -37,41 +36,14 @@ use libp2p::{
 use relay::RelayNode;
 use routes::{cors, delegate, invoke, open_host_key, relay_addr};
 use std::{collections::HashMap, sync::RwLock};
-use tracing_log::LogTracer;
-use tracing_subscriber::{layer::SubscriberExt, Layer, Registry};
 
 #[get("/healthz")]
 pub fn healthcheck() {}
 
-pub fn tracing_try_init(config: &config::Logging) {
-    LogTracer::init().unwrap();
-    let env_filter = tracing_subscriber::EnvFilter::from_default_env();
-    let subscriber = tracing_subscriber::fmt::layer();
-    let log = match config.format {
-        config::LoggingFormat::Text => subscriber.boxed(),
-        config::LoggingFormat::Json => subscriber.json().boxed(),
-    };
-    let telemetry = if config.tracing.enabled {
-        let tracer = opentelemetry_jaeger::new_pipeline()
-            .with_service_name("kepler")
-            .install_batch(opentelemetry::runtime::Tokio)
-            .unwrap();
-        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-        Some(telemetry)
-    } else {
-        None
-    };
-    let collector = Registry::default()
-        .with(env_filter)
-        .with(log)
-        .with(telemetry);
-    set_global_default(collector).unwrap();
-}
-
 pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     let kepler_config = config.extract::<config::Config>()?;
 
-    tracing_try_init(&kepler_config.log);
+    tracing::tracing_try_init(&kepler_config.log);
 
     storage::KV::healthcheck(kepler_config.storage.indexes.clone()).await?;
     storage::StorageUtils::new(kepler_config.storage.blocks.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,11 @@ pub mod resource;
 pub mod routes;
 pub mod siwe;
 pub mod storage;
+mod tracing;
 pub mod transport;
 pub mod zcap;
 
+use ::tracing::subscriber::set_global_default;
 use libp2p::{
     identity::{ed25519::Keypair as Ed25519Keypair, Keypair},
     PeerId,
@@ -35,19 +37,41 @@ use libp2p::{
 use relay::RelayNode;
 use routes::{cors, delegate, invoke, open_host_key, relay_addr};
 use std::{collections::HashMap, sync::RwLock};
+use tracing_log::LogTracer;
+use tracing_subscriber::{layer::SubscriberExt, Layer, Registry};
 
 #[get("/healthz")]
 pub fn healthcheck() {}
 
-pub fn tracing_try_init() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init()
-        .ok();
+pub fn tracing_try_init(config: &config::Logging) {
+    LogTracer::init().unwrap();
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env();
+    let subscriber = tracing_subscriber::fmt::layer();
+    let log = match config.format {
+        config::LoggingFormat::Text => subscriber.boxed(),
+        config::LoggingFormat::Json => subscriber.json().boxed(),
+    };
+    let telemetry = if config.tracing.enabled {
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("kepler")
+            .install_batch(opentelemetry::runtime::Tokio)
+            .unwrap();
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        Some(telemetry)
+    } else {
+        None
+    };
+    let collector = Registry::default()
+        .with(env_filter)
+        .with(log)
+        .with(telemetry);
+    set_global_default(collector).unwrap();
 }
 
 pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     let kepler_config = config.extract::<config::Config>()?;
+
+    tracing_try_init(&kepler_config.log);
 
     storage::KV::healthcheck(kepler_config.storage.indexes.clone()).await?;
     storage::StorageUtils::new(kepler_config.storage.blocks.clone())
@@ -80,6 +104,9 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
                 resp.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
             })
         }))
+        .attach(tracing::TracingFairing {
+            header_name: kepler_config.log.tracing.traceheader,
+        })
         .manage(relay_node)
         .manage(RwLock::new(HashMap::<PeerId, Ed25519Keypair>::new())))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use kepler::{app, config, prometheus, tracing_try_init};
+use kepler::{app, config, prometheus};
 use rocket::{
     figment::providers::{Env, Format, Serialized, Toml},
     tokio,
@@ -10,8 +10,6 @@ use rocket::{
 
 #[rocket::main]
 async fn main() {
-    tracing_try_init();
-
     let config = rocket::figment::Figment::from(rocket::Config::default())
         .merge(Serialized::defaults(config::Config::default()))
         .merge(Toml::file("kepler.toml").nested())
@@ -27,7 +25,7 @@ async fn main() {
     }));
 
     tokio::select! {
-        r = rocket.launch() => r.unwrap(),
+        r = rocket.launch() => {let _ = r.unwrap();},
         r = prometheus => r.unwrap()
     };
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -100,7 +100,6 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn relay() -> Result<()> {
-        crate::tracing_try_init();
         let relay = test_relay().await?;
 
         let dir = tempdir::TempDir::new("relay")?;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -105,7 +105,7 @@ pub async fn invoke(
 ) -> Result<InvocationResponse, (Status, String)> {
     let action_label = i.prometheus_label().to_string();
     let span = info_span!(parent: &req_span.0, "invoke", action = %action_label);
-    // let _span_guard = span.enter();
+    // Instrumenting async block to handle yielding properly
     async move {
         use InvokeAuthWrapper::*;
         let timer = crate::prometheus::AUTHORIZED_INVOKE_HISTOGRAM

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -357,10 +357,8 @@ impl AuthorizationPolicy<SIWETokens> for Manifest {
 
 #[test]
 async fn basic() {
-    use crate::tracing_try_init;
     use rocket::{build, http::Header, local::asynchronous::Client};
 
-    tracing_try_init();
     let d = base64::encode_config(
         r#"["test.org wants you to sign in with your Ethereum account:\n0x6c3Ca9380307EEDa246B7606B43b33F3e0786C79\n\nAuthorize this provider to host your Orbit\n\nURI: peer:12D3KooWSJT2PD5c1rEAD959q9kChGcWUnkkUzku28uY5pqegkuW\nVersion: 1\nChain ID: 1\nNonce: 3A9S4Ar7YibfspTb2\nIssued At: 2022-03-16T15:03:36.775Z\nExpiration Time: 2022-03-16T15:05:36.775Z\nResources:\n- kepler:pkh:eip155:1:0x6c3Ca9380307EEDa246B7606B43b33F3e0786C79://default#peer","0x6909694c1afe49fbe9350da8f89333397657ae46d9898dccdef45a38cf39e8fd1527e81e79b52db3f2ad2239c07cab8888f4882faf453c032c0e4df3d9c4902d1b"]"#,
         base64::URL_SAFE,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,6 +17,7 @@ use libipld::cid::{multibase::Base, Cid};
 use libp2p::identity::ed25519::Keypair as Ed25519Keypair;
 use rocket::tokio::fs;
 use std::{path::PathBuf, str::FromStr};
+use tracing::instrument;
 
 mod dynamodb;
 mod indexes;
@@ -287,6 +288,7 @@ impl BlockStore for BlockStores {
         }
     }
 
+    #[instrument(skip(self, cid))]
     async fn get(&self, cid: &Cid) -> Result<Option<Block>, Error> {
         match self {
             Self::S3(r) => r.get(cid).await,
@@ -294,6 +296,7 @@ impl BlockStore for BlockStores {
         }
     }
 
+    #[instrument(skip(self, block))]
     async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
         match self {
             Self::S3(r) => r.put(block).await,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -288,7 +288,7 @@ impl BlockStore for BlockStores {
         }
     }
 
-    #[instrument(skip(self, cid))]
+    #[instrument(name = "blocks::get", skip_all)]
     async fn get(&self, cid: &Cid) -> Result<Option<Block>, Error> {
         match self {
             Self::S3(r) => r.get(cid).await,
@@ -296,7 +296,7 @@ impl BlockStore for BlockStores {
         }
     }
 
-    #[instrument(skip(self, block))]
+    #[instrument(name = "blocks::put", skip_all)]
     async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
         match self {
             Self::S3(r) => r.put(block).await,

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,39 +1,16 @@
-use rocket::http::Status;
-use rocket::request::FromRequest;
-use rocket::request::Outcome;
-use rocket::serde::{json::Json, Serialize};
+use opentelemetry::trace::TraceContextExt;
 use rocket::{
     fairing::{Fairing, Info, Kind},
+    http::Status,
+    request::{FromRequest, Outcome},
     Data, Request, Response,
 };
-
-use opentelemetry::trace::TraceContextExt;
-use tracing::{field, info_span, Span};
+use tracing::{field, info_span, subscriber::set_global_default, Span};
+use tracing_log::LogTracer;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-// use tracing_log::LogTracer;
+use tracing_subscriber::{layer::SubscriberExt, Layer, Registry};
 
-// use tracing_subscriber::Layer;
-// use tracing_subscriber::{registry::LookupSpan, EnvFilter};
-use uuid::Uuid;
-// use yansi::Paint;
-
-// Spans
-
-#[derive(Clone, Debug)]
-pub struct RequestId<T = String>(pub T);
-
-// // Allows a route to access the request id
-// #[rocket::async_trait]
-// impl<'r> FromRequest<'r> for RequestId {
-//     type Error = ();
-
-//     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, ()> {
-//         match &*request.local_cache(|| RequestId::<Option<String>>(None)) {
-//             RequestId(Some(request_id)) => Outcome::Success(RequestId(request_id.to_owned())),
-//             RequestId(None) => Outcome::Failure((Status::InternalServerError, ())),
-//         }
-//     }
-// }
+use crate::config;
 
 #[derive(Clone)]
 pub struct TracingSpan(pub Span);
@@ -51,37 +28,11 @@ impl Fairing for TracingFairing {
         }
     }
     async fn on_request(&self, req: &mut Request<'_>, _data: &mut Data<'_>) {
-        // let user_agent = req.headers().get_one("User-Agent").unwrap_or("");
-        // let trace_id = req
-        //     .headers()
-        //     .get_one(&self.header_name)
-        //     .map(ToString::to_string)
-        //     .unwrap_or_else(|| Uuid::new_v4().to_string());
-
-        // let mut carrier = HashMap::from([("trace_id", trace_id)]);
-        // let propagator = opentelemetry_jaeger::Propagator::new();
-        // let parent_context = propagator.extract(&carrier);
-
-        // req.local_cache(|| Some(RequestId(request_id.to_owned())));
-
-        let span = info_span!(
-            parent: None,
-            "request",
-            // otel.name=%format!("{} {}", req.method(), req.uri().path()),
-            // http.method = %req.method(),
-            // http.uri = %req.uri().path(),
-            // http.user_agent=%user_agent,
-            // http.status_code = tracing::field::Empty,
-            // http.request_id=%request_id,
-            // trace_id=%trace_id
-            trace_id = field::Empty
-        );
-        // span.set_parent(parent_context.clone());
+        let span = info_span!(parent: None, "request", trace_id = field::Empty);
         span.record(
             "trace_id",
             &field::display(&span.context().span().span_context().trace_id()),
         );
-
         req.local_cache(|| Some(TracingSpan(span)));
     }
 
@@ -89,24 +40,11 @@ impl Fairing for TracingFairing {
         if let Some(TracingSpan(span)) = req.local_cache(|| Option::<TracingSpan>::None).to_owned()
         {
             let trace_id = span.context().span().span_context().trace_id();
-            // let _entered_span = span.entered();
-            // _entered_span.record("http.status_code", &res.status().code);
-
-            // if let Some(request_id) = &req.local_cache(|| RequestId::<Option<String>>(None)).0 {
-            //     info!("Returning request {} with {}", request_id, res.status());
-            // }
             res.set_raw_header(self.header_name.clone(), format!("{}", trace_id));
-
-            // drop(_entered_span);
         }
-
-        // if let Some(request_id) = &req.local_cache(|| RequestId::<Option<String>>(None)).0 {
-        //     res.set_raw_header(self.header_name.clone(), request_id);
-        // }
     }
 }
 
-// Allows a route to access the span
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for TracingSpan {
     type Error = ();
@@ -119,165 +57,27 @@ impl<'r> FromRequest<'r> for TracingSpan {
     }
 }
 
-#[derive(Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct OutputData<'a> {
-    pub message: &'a str,
-    pub request_id: String,
+pub fn tracing_try_init(config: &config::Logging) {
+    LogTracer::init().unwrap();
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env();
+    let subscriber = tracing_subscriber::fmt::layer();
+    let log = match config.format {
+        config::LoggingFormat::Text => subscriber.boxed(),
+        config::LoggingFormat::Json => subscriber.json().boxed(),
+    };
+    let telemetry = if config.tracing.enabled {
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("kepler")
+            .install_batch(opentelemetry::runtime::Tokio)
+            .unwrap();
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        Some(telemetry)
+    } else {
+        None
+    };
+    let collector = Registry::default()
+        .with(env_filter)
+        .with(log)
+        .with(telemetry);
+    set_global_default(collector).unwrap();
 }
-
-// #[get("/abc")]
-// pub async fn abc<'a>(
-//     span: TracingSpan,
-//     request_id: RequestId,
-// ) -> Result<Json<OutputData<'a>>, (Status, Json<OutputData<'a>>)> {
-//     let entered = span.0.enter();
-//     info!("Hello World");
-
-//     let mock_data = OutputData {
-//         message: "Hello World",
-//         request_id: request_id.0,
-//     };
-//     span.0.record(
-//         "output",
-//         &serde_json::to_string(&mock_data).unwrap().as_str(),
-//     );
-//     drop(entered);
-//     Err((Status::NotFound, Json(mock_data)))
-// }
-
-// // Logging
-
-// use tracing_subscriber::field::MakeExt;
-
-// pub enum LogType {
-//     Formatted,
-//     Json,
-// }
-
-// impl From<String> for LogType {
-//     fn from(input: String) -> Self {
-//         match input.as_str() {
-//             "formatted" => Self::Formatted,
-//             "json" => Self::Json,
-//             _ => panic!("Unkown log type {}", input),
-//         }
-//     }
-// }
-
-// pub fn default_logging_layer<S>() -> impl Layer<S>
-// where
-//     S: tracing::Subscriber,
-//     S: for<'span> LookupSpan<'span>,
-// {
-//     let field_format = tracing_subscriber::fmt::format::debug_fn(|writer, field, value| {
-//         // We'll format the field name and value separated with a colon.
-//         if field.name() == "message" {
-//             write!(writer, "{:?}", Paint::new(value).bold())
-//         } else {
-//             write!(writer, "{}: {:?}", field, Paint::default(value).bold())
-//         }
-//     })
-//     .delimited(", ")
-//     .display_messages();
-
-//     tracing_subscriber::fmt::layer()
-//         .fmt_fields(field_format)
-//         // Configure the formatter to use `print!` rather than
-//         // `stdout().write_str(...)`, so that logs are captured by libtest's test
-//         // capturing.
-//         .with_test_writer()
-// }
-
-// pub fn json_logging_layer<
-//     S: for<'a> tracing_subscriber::registry::LookupSpan<'a> + tracing::Subscriber,
-// >() -> impl tracing_subscriber::Layer<S> {
-//     Paint::disable();
-
-//     tracing_subscriber::fmt::layer()
-//         .json()
-//         // Configure the formatter to use `print!` rather than
-//         // `stdout().write_str(...)`, so that logs are captured by libtest's test
-//         // capturing.
-//         .with_test_writer()
-// }
-
-// #[derive(PartialEq, Eq, Debug, Clone, Copy)]
-// pub enum LogLevel {
-//     /// Only shows errors and warnings: `"critical"`.
-//     Critical,
-//     /// Shows errors, warnings, and some informational messages that are likely
-//     /// to be relevant when troubleshooting such as configuration: `"support"`.
-//     Support,
-//     /// Shows everything except debug and trace information: `"normal"`.
-//     Normal,
-//     /// Shows everything: `"debug"`.
-//     Debug,
-//     /// Shows nothing: "`"off"`".
-//     Off,
-// }
-
-// impl From<&str> for LogLevel {
-//     fn from(s: &str) -> Self {
-//         return match &*s.to_ascii_lowercase() {
-//             "critical" => LogLevel::Critical,
-//             "support" => LogLevel::Support,
-//             "normal" => LogLevel::Normal,
-//             "debug" => LogLevel::Debug,
-//             "off" => LogLevel::Off,
-//             _ => panic!("a log level (off, debug, normal, support, critical)"),
-//         };
-//     }
-// }
-
-// pub fn filter_layer(level: LogLevel) -> EnvFilter {
-//     let filter_str = match level {
-//         LogLevel::Critical => "warn,hyper=off,rustls=off",
-//         LogLevel::Support => "warn,rocket::support=info,hyper=off,rustls=off",
-//         LogLevel::Normal => "info,hyper=off,rustls=off",
-//         LogLevel::Debug => "trace",
-//         LogLevel::Off => "off",
-//     };
-
-//     tracing_subscriber::filter::EnvFilter::try_new(filter_str).expect("filter string must parse")
-// }
-
-// // Rocket setup
-
-// #[launch]
-// fn rocket() -> _ {
-//     use tracing_subscriber::prelude::*;
-
-//     LogTracer::init().expect("Unable to setup log tracer!");
-
-//     let log_type =
-//         LogType::from(std::env::var("LOG_TYPE").unwrap_or_else(|_| "formatted".to_string()));
-//     let log_level = LogLevel::from(
-//         std::env::var("LOG_LEVEL")
-//             .unwrap_or_else(|_| "normal".to_string())
-//             .as_str(),
-//     );
-
-//     match log_type {
-//         LogType::Formatted => {
-//             tracing::subscriber::set_global_default(
-//                 tracing_subscriber::registry()
-//                     .with(default_logging_layer())
-//                     .with(filter_layer(log_level)),
-//             )
-//             .unwrap();
-//         }
-//         LogType::Json => {
-//             tracing::subscriber::set_global_default(
-//                 tracing_subscriber::registry()
-//                     .with(json_logging_layer())
-//                     .with(filter_layer(log_level)),
-//             )
-//             .unwrap();
-//         }
-//     };
-
-//     rocket::build()
-//         .mount("/", routes![abc])
-//         .attach(TracingFairing)
-// }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,283 @@
+use rocket::http::Status;
+use rocket::request::FromRequest;
+use rocket::request::Outcome;
+use rocket::serde::{json::Json, Serialize};
+use rocket::{
+    fairing::{Fairing, Info, Kind},
+    Data, Request, Response,
+};
+
+use opentelemetry::trace::TraceContextExt;
+use tracing::{field, info_span, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+// use tracing_log::LogTracer;
+
+// use tracing_subscriber::Layer;
+// use tracing_subscriber::{registry::LookupSpan, EnvFilter};
+use uuid::Uuid;
+// use yansi::Paint;
+
+// Spans
+
+#[derive(Clone, Debug)]
+pub struct RequestId<T = String>(pub T);
+
+// // Allows a route to access the request id
+// #[rocket::async_trait]
+// impl<'r> FromRequest<'r> for RequestId {
+//     type Error = ();
+
+//     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, ()> {
+//         match &*request.local_cache(|| RequestId::<Option<String>>(None)) {
+//             RequestId(Some(request_id)) => Outcome::Success(RequestId(request_id.to_owned())),
+//             RequestId(None) => Outcome::Failure((Status::InternalServerError, ())),
+//         }
+//     }
+// }
+
+#[derive(Clone)]
+pub struct TracingSpan(pub Span);
+
+pub struct TracingFairing {
+    pub header_name: String,
+}
+
+#[rocket::async_trait]
+impl Fairing for TracingFairing {
+    fn info(&self) -> Info {
+        Info {
+            name: "Tracing Fairing",
+            kind: Kind::Request | Kind::Response,
+        }
+    }
+    async fn on_request(&self, req: &mut Request<'_>, _data: &mut Data<'_>) {
+        // let user_agent = req.headers().get_one("User-Agent").unwrap_or("");
+        // let trace_id = req
+        //     .headers()
+        //     .get_one(&self.header_name)
+        //     .map(ToString::to_string)
+        //     .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        // let mut carrier = HashMap::from([("trace_id", trace_id)]);
+        // let propagator = opentelemetry_jaeger::Propagator::new();
+        // let parent_context = propagator.extract(&carrier);
+
+        // req.local_cache(|| Some(RequestId(request_id.to_owned())));
+
+        let span = info_span!(
+            parent: None,
+            "request",
+            // otel.name=%format!("{} {}", req.method(), req.uri().path()),
+            // http.method = %req.method(),
+            // http.uri = %req.uri().path(),
+            // http.user_agent=%user_agent,
+            // http.status_code = tracing::field::Empty,
+            // http.request_id=%request_id,
+            // trace_id=%trace_id
+            trace_id = field::Empty
+        );
+        // span.set_parent(parent_context.clone());
+        span.record(
+            "trace_id",
+            &field::display(&span.context().span().span_context().trace_id()),
+        );
+
+        req.local_cache(|| Some(TracingSpan(span)));
+    }
+
+    async fn on_response<'r>(&self, req: &'r Request<'_>, res: &mut Response<'r>) {
+        if let Some(TracingSpan(span)) = req.local_cache(|| Option::<TracingSpan>::None).to_owned()
+        {
+            let trace_id = span.context().span().span_context().trace_id();
+            // let _entered_span = span.entered();
+            // _entered_span.record("http.status_code", &res.status().code);
+
+            // if let Some(request_id) = &req.local_cache(|| RequestId::<Option<String>>(None)).0 {
+            //     info!("Returning request {} with {}", request_id, res.status());
+            // }
+            res.set_raw_header(self.header_name.clone(), format!("{}", trace_id));
+
+            // drop(_entered_span);
+        }
+
+        // if let Some(request_id) = &req.local_cache(|| RequestId::<Option<String>>(None)).0 {
+        //     res.set_raw_header(self.header_name.clone(), request_id);
+        // }
+    }
+}
+
+// Allows a route to access the span
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for TracingSpan {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, ()> {
+        match &*request.local_cache(|| Option::<TracingSpan>::None) {
+            Some(TracingSpan(span)) => Outcome::Success(TracingSpan(span.to_owned())),
+            None => Outcome::Failure((Status::InternalServerError, ())),
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputData<'a> {
+    pub message: &'a str,
+    pub request_id: String,
+}
+
+// #[get("/abc")]
+// pub async fn abc<'a>(
+//     span: TracingSpan,
+//     request_id: RequestId,
+// ) -> Result<Json<OutputData<'a>>, (Status, Json<OutputData<'a>>)> {
+//     let entered = span.0.enter();
+//     info!("Hello World");
+
+//     let mock_data = OutputData {
+//         message: "Hello World",
+//         request_id: request_id.0,
+//     };
+//     span.0.record(
+//         "output",
+//         &serde_json::to_string(&mock_data).unwrap().as_str(),
+//     );
+//     drop(entered);
+//     Err((Status::NotFound, Json(mock_data)))
+// }
+
+// // Logging
+
+// use tracing_subscriber::field::MakeExt;
+
+// pub enum LogType {
+//     Formatted,
+//     Json,
+// }
+
+// impl From<String> for LogType {
+//     fn from(input: String) -> Self {
+//         match input.as_str() {
+//             "formatted" => Self::Formatted,
+//             "json" => Self::Json,
+//             _ => panic!("Unkown log type {}", input),
+//         }
+//     }
+// }
+
+// pub fn default_logging_layer<S>() -> impl Layer<S>
+// where
+//     S: tracing::Subscriber,
+//     S: for<'span> LookupSpan<'span>,
+// {
+//     let field_format = tracing_subscriber::fmt::format::debug_fn(|writer, field, value| {
+//         // We'll format the field name and value separated with a colon.
+//         if field.name() == "message" {
+//             write!(writer, "{:?}", Paint::new(value).bold())
+//         } else {
+//             write!(writer, "{}: {:?}", field, Paint::default(value).bold())
+//         }
+//     })
+//     .delimited(", ")
+//     .display_messages();
+
+//     tracing_subscriber::fmt::layer()
+//         .fmt_fields(field_format)
+//         // Configure the formatter to use `print!` rather than
+//         // `stdout().write_str(...)`, so that logs are captured by libtest's test
+//         // capturing.
+//         .with_test_writer()
+// }
+
+// pub fn json_logging_layer<
+//     S: for<'a> tracing_subscriber::registry::LookupSpan<'a> + tracing::Subscriber,
+// >() -> impl tracing_subscriber::Layer<S> {
+//     Paint::disable();
+
+//     tracing_subscriber::fmt::layer()
+//         .json()
+//         // Configure the formatter to use `print!` rather than
+//         // `stdout().write_str(...)`, so that logs are captured by libtest's test
+//         // capturing.
+//         .with_test_writer()
+// }
+
+// #[derive(PartialEq, Eq, Debug, Clone, Copy)]
+// pub enum LogLevel {
+//     /// Only shows errors and warnings: `"critical"`.
+//     Critical,
+//     /// Shows errors, warnings, and some informational messages that are likely
+//     /// to be relevant when troubleshooting such as configuration: `"support"`.
+//     Support,
+//     /// Shows everything except debug and trace information: `"normal"`.
+//     Normal,
+//     /// Shows everything: `"debug"`.
+//     Debug,
+//     /// Shows nothing: "`"off"`".
+//     Off,
+// }
+
+// impl From<&str> for LogLevel {
+//     fn from(s: &str) -> Self {
+//         return match &*s.to_ascii_lowercase() {
+//             "critical" => LogLevel::Critical,
+//             "support" => LogLevel::Support,
+//             "normal" => LogLevel::Normal,
+//             "debug" => LogLevel::Debug,
+//             "off" => LogLevel::Off,
+//             _ => panic!("a log level (off, debug, normal, support, critical)"),
+//         };
+//     }
+// }
+
+// pub fn filter_layer(level: LogLevel) -> EnvFilter {
+//     let filter_str = match level {
+//         LogLevel::Critical => "warn,hyper=off,rustls=off",
+//         LogLevel::Support => "warn,rocket::support=info,hyper=off,rustls=off",
+//         LogLevel::Normal => "info,hyper=off,rustls=off",
+//         LogLevel::Debug => "trace",
+//         LogLevel::Off => "off",
+//     };
+
+//     tracing_subscriber::filter::EnvFilter::try_new(filter_str).expect("filter string must parse")
+// }
+
+// // Rocket setup
+
+// #[launch]
+// fn rocket() -> _ {
+//     use tracing_subscriber::prelude::*;
+
+//     LogTracer::init().expect("Unable to setup log tracer!");
+
+//     let log_type =
+//         LogType::from(std::env::var("LOG_TYPE").unwrap_or_else(|_| "formatted".to_string()));
+//     let log_level = LogLevel::from(
+//         std::env::var("LOG_LEVEL")
+//             .unwrap_or_else(|_| "normal".to_string())
+//             .as_str(),
+//     );
+
+//     match log_type {
+//         LogType::Formatted => {
+//             tracing::subscriber::set_global_default(
+//                 tracing_subscriber::registry()
+//                     .with(default_logging_layer())
+//                     .with(filter_layer(log_level)),
+//             )
+//             .unwrap();
+//         }
+//         LogType::Json => {
+//             tracing::subscriber::set_global_default(
+//                 tracing_subscriber::registry()
+//                     .with(json_logging_layer())
+//                     .with(filter_layer(log_level)),
+//             )
+//             .unwrap();
+//         }
+//     };
+
+//     rocket::build()
+//         .mount("/", routes![abc])
+//         .attach(TracingFairing)
+// }


### PR DESCRIPTION
Basic Jaeger implementation. It doesn't support propagation, behaves as a compactor instead of being able to rely on an agent, and only instruments the invoke endpoint. Things will evolve as `tracing` 0.2 comes out and the OpenTelemetry standardisation converges, and as Rocket gets native tracing support (or whether we move to Axum).

Also adds support for JSON formatted logs.

Here's an example trace:
<img width="1476" alt="Screenshot 2022-05-13 at 10 30 10" src="https://user-images.githubusercontent.com/12815410/168254993-09331ddf-a549-46a3-9c98-3037576a6ca7.png">
This example was run with Tempo, and here is the cargo command:
```
RUST_LOG=info KEPLER_LOG_FORMAT=Json KEPLER_LOG_TRACING_ENABLED=true OTEL_EXPORTER_JAEGER_ENDPOINT="http://127.0.0.1:14268/api/traces?format=jaeger.thrift" cargo run
```

Also updated to Rust 2021 and Rocket `0.5.0-rc.2`.