### PR TITLE
Add 'lib' to sdk-wasm crate-type.

### DIFF
--- a/sdk-wasm/Cargo.toml
+++ b/sdk-wasm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 base64 = "0.13"


### PR DESCRIPTION
This allows the crate to be imported into another crate that can build
the wasm alongside other functionality.