### PR TITLE
Fix jwk algorithm for invocations.

### DIFF
--- a/lib/src/authorization.rs
+++ b/lib/src/authorization.rs
@@ -98,7 +98,7 @@ pub async fn make_invocation(
         proof: vec![delegation],
         attenuation: vec![invocation_target.try_into()?],
     }
-    .sign(jwk.algorithm.unwrap_or_default(), jwk)?)
+    .sign(jwk.get_algorithm().unwrap_or_default(), jwk)?)
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Currently get the following error when making an invocation with a JWK generated outside of the SDK:
```'failed to generate proof for invocation: Unsupported algorithm'```

`JWK::generate_ed25519` for example does not populate the `alg` field in the generated JWK, but `JWK::get_algorithm` will return the correct algorithm for some curves.