### PR TITLE
fix docker container

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,3 +67,8 @@ jobs:
     - name: Fmt
       working-directory: ${{ matrix.pkg }}
       run: cargo fmt -- --check
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - run: docker build .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,4 +71,5 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - run: docker build .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,6 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-
     - name: Build
       working-directory: ${{ matrix.pkg }}
       run: cargo build
@@ -48,9 +45,6 @@ jobs:
       if: ${{ matrix.pkg == 'sdk-wasm' }}
       run: |
         rustup target add wasm32-unknown-unknown
-
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
 
     - name: Clippy
       working-directory: ${{ matrix.pkg }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,9 +67,3 @@ jobs:
     - name: Fmt
       working-directory: ${{ matrix.pkg }}
       run: cargo fmt -- --check
-
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: docker build .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,15 +1171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +2943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 1.14.0",
+ "time 0.3.17",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -3000,7 +2992,6 @@ dependencies = [
  "libipld-core",
  "libipld-json",
  "libipld-macro",
- "libipld-pb",
  "log",
  "multihash",
  "parking_lot 0.12.1",
@@ -3068,18 +3059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libipld-pb"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c003be513496578115256a1b4ac7b80d4ece2462c9869dfb736fd30d8bb1d1c0"
-dependencies = [
- "libipld-core",
- "prost 0.10.4",
- "prost-build 0.10.4",
- "thiserror",
-]
-
-[[package]]
 name = "libm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,8 +3123,8 @@ dependencies = [
  "multistream-select",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "rw-stream-sink",
  "sha2 0.10.6",
@@ -3182,8 +3161,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "smallvec",
 ]
@@ -3201,8 +3180,8 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "lru",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "prost-codec",
  "smallvec",
  "thiserror",
@@ -3226,8 +3205,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "sha2 0.10.6",
  "smallvec",
@@ -3282,8 +3261,8 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "log",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "sha2 0.10.6",
  "snow",
@@ -3324,8 +3303,8 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "pin-project",
- "prost 0.11.6",
- "prost-build 0.11.6",
+ "prost",
+ "prost-build",
  "prost-codec",
  "rand 0.8.5",
  "smallvec",
@@ -4470,44 +4449,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive 0.10.1",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
- "prost-derive 0.11.6",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.10.4",
- "prost-types 0.10.1",
- "regex",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4524,8 +4471,8 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.11.6",
- "prost-types 0.11.6",
+ "prost",
+ "prost-types",
  "regex",
  "syn",
  "tempfile",
@@ -4540,22 +4487,9 @@ checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "prost 0.11.6",
+ "prost",
  "thiserror",
  "unsigned-varint",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4573,22 +4507,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost 0.10.4",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
- "prost 0.11.6",
+ "prost",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,21 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.6",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -25,6 +35,17 @@ checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
  "crypto-common",
  "generic-array 0.14.6",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -48,6 +69,20 @@ dependencies = [
  "cfg-if",
  "cipher 0.4.3",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead 0.3.2",
+ "aes 0.6.0",
+ "cipher 0.2.5",
+ "ctr 0.6.0",
+ "ghash 0.3.1",
+ "subtle",
 ]
 
 [[package]]
@@ -79,14 +114,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
+name = "aes-soft"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
- "getrandom 0.2.8",
- "once_cell",
- "version_check 0.9.4",
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -114,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +180,73 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "asn1-rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
+dependencies = [
+ "asn1-rs-derive 0.1.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+dependencies = [
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "asn1_der"
@@ -868,6 +985,16 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
+dependencies = [
+ "block-padding 0.2.1",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "block-modes"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
@@ -1067,6 +1194,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
+name = "ccm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca1a8fbc20b50ac9673ff014abfb2b5f4085ee1a850d408f14a159c5853ac7"
+dependencies = [
+ "aead 0.3.2",
+ "cipher 0.2.5",
+ "subtle",
+]
+
+[[package]]
 name = "cfb-mode"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,10 +1268,19 @@ checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
  "core2",
  "multibase 0.9.1",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_bytes",
  "unsigned-varint",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1238,7 +1385,7 @@ dependencies = [
  "aes-gcm 0.10.1",
  "base64 0.20.0",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "percent-encoding",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -1280,6 +1427,27 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crc24"
@@ -1324,7 +1492,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
@@ -1377,6 +1545,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array 0.14.6",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.6",
+ "subtle",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1585,15 @@ dependencies = [
 
 [[package]]
 name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
@@ -1411,17 +1608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.3",
-]
-
-[[package]]
-name = "cuckoofilter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
-dependencies = [
- "byteorder",
- "fnv",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -1634,7 +1820,7 @@ checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid 0.7.1",
  "crypto-bigint 0.3.2",
- "pem-rfc7468",
+ "pem-rfc7468 0.3.1",
 ]
 
 [[package]]
@@ -1644,7 +1830,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid 0.9.1",
+ "pem-rfc7468 0.6.0",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1896,6 +2111,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2181,8 @@ dependencies = [
  "ff",
  "generic-array 0.14.6",
  "group",
+ "hkdf",
+ "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
@@ -2202,6 +2430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
+dependencies = [
+ "futures-io",
+ "rustls 0.20.8",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2545,16 @@ dependencies = [
 
 [[package]]
 name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval 0.4.5",
+]
+
+[[package]]
+name = "ghash"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
@@ -2383,9 +2632,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "headers"
@@ -2448,7 +2694,27 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.1",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2635,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c008e570a43c00de6aed9714035e5ea6a498c255323db9091722af6ee67dd"
+checksum = "ba7abdbb86e485125dad06c2691e1e393bf3b08c7b743b43aa162a00fd39062e"
 dependencies = [
  "async-io",
  "core-foundation",
@@ -2648,6 +2914,7 @@ dependencies = [
  "log",
  "rtnetlink",
  "system-configuration",
+ "tokio",
  "windows 0.34.0",
 ]
 
@@ -2691,6 +2958,25 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "interceptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8a11ae2da61704edada656798b61c94b35ecac2c58eb955156987d5e6be90b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -2993,7 +3279,7 @@ dependencies = [
  "libipld-json",
  "libipld-macro",
  "log",
- "multihash",
+ "multihash 0.16.3",
  "parking_lot 0.12.1",
  "thiserror",
 ]
@@ -3032,7 +3318,7 @@ dependencies = [
  "cid",
  "core2",
  "multibase 0.9.1",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "thiserror",
 ]
@@ -3044,7 +3330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18aa481a87f084d98473dd9ece253a9569c762b75f6bbba8217d54e48c9d63b3"
 dependencies = [
  "libipld-core",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_json",
 ]
@@ -3072,29 +3358,25 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libp2p"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
+version = "0.51.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "getrandom 0.2.8",
  "instant",
- "lazy_static",
  "libp2p-core",
  "libp2p-dns",
- "libp2p-floodsub",
- "libp2p-identify",
- "libp2p-kad",
+ "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
- "libp2p-relay",
+ "libp2p-quic",
  "libp2p-swarm",
- "libp2p-swarm-derive",
  "libp2p-tcp",
+ "libp2p-webrtc",
  "libp2p-yamux",
  "multiaddr",
  "parking_lot 0.12.1",
@@ -3104,9 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799676bb0807c788065e57551c6527d461ad572162b0519d1958946ff9e0539d"
+version = "0.39.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3116,17 +3397,17 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "lazy_static",
  "log",
  "multiaddr",
- "multihash",
+ "multihash 0.17.0",
  "multistream-select",
+ "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
+ "sec1",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -3137,9 +3418,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
+version = "0.39.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3150,92 +3430,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-floodsub"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a413aac86cd30078192e5c110fd4c859ba36a6d694e040e75f1ef0dc41583"
+name = "libp2p-mdns"
+version = "0.43.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
- "cuckoofilter",
- "fnv",
+ "data-encoding",
  "futures",
+ "if-watch",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
  "rand 0.8.5",
  "smallvec",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
-dependencies = [
- "asynchronous-codec",
- "futures",
- "futures-timer",
- "libp2p-core",
- "libp2p-swarm",
- "log",
- "lru",
- "prost",
- "prost-build",
- "prost-codec",
- "smallvec",
- "thiserror",
- "void",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6721c200e2021f6c3fab8b6cf0272ead8912d871610ee194ebd628cecf428f22"
-dependencies = [
- "arrayvec 0.7.2",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core",
- "libp2p-swarm",
- "log",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "sha2 0.10.6",
- "smallvec",
- "thiserror",
- "uint",
- "unsigned-varint",
+ "socket2",
+ "tokio",
+ "trust-dns-proto",
  "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
+version = "0.12.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "libp2p-core",
- "libp2p-identify",
- "libp2p-kad",
  "libp2p-ping",
- "libp2p-relay",
  "libp2p-swarm",
  "prometheus-client",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692664acfd98652de739a8acbb0a0d670f1d67190a49be6b4395e22c37337d89"
+version = "0.39.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3251,31 +3478,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048155686bd81fe6cb5efdef0c6290f25ad32a0a42e8f4f72625cf6a505a206f"
+version = "0.42.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "lazy_static",
  "libp2p-core",
  "log",
- "prost",
- "prost-build",
+ "once_cell",
+ "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.6",
  "snow",
  "static_assertions",
- "x25519-dalek",
+ "thiserror",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7228b9318d34689521349a86eb39a3c3a802c9efc99a0568062ffb80913e3f91"
+version = "0.42.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3288,36 +3513,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-relay"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3266c322fa094e229eb63c2644b0209a7e1db1d78ab6f03956eb3534bb514155"
+name = "libp2p-quic"
+version = "0.7.0-alpha.2"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
- "asynchronous-codec",
  "bytes",
- "either",
  "futures",
  "futures-timer",
- "instant",
+ "if-watch",
  "libp2p-core",
- "libp2p-swarm",
+ "libp2p-tls",
  "log",
- "pin-project",
- "prost",
- "prost-build",
- "prost-codec",
+ "parking_lot 0.12.1",
+ "quinn-proto",
  "rand 0.8.5",
- "smallvec",
- "static_assertions",
+ "rustls 0.20.8",
  "thiserror",
- "void",
+ "tokio",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
+version = "0.42.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "either",
  "fnv",
@@ -3330,25 +3548,14 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "thiserror",
+ "tokio",
  "void",
 ]
 
 [[package]]
-name = "libp2p-swarm-derive"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eddc4497a8b5a506013c40e8189864f9c3a00db2b25671f428ae9007f3ba32"
-dependencies = [
- "heck",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "libp2p-tcp"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9839d96761491c6d3e238e70554b856956fca0ab60feb9de2cd08eed4473fa92"
+version = "0.39.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3361,10 +3568,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-tls"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "rcgen 0.10.0",
+ "ring",
+ "rustls 0.20.8",
+ "thiserror",
+ "webpki 0.22.0",
+ "x509-parser 0.14.0",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-webrtc"
+version = "0.4.0-alpha.2"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "futures-timer",
+ "hex",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-noise",
+ "log",
+ "multihash 0.17.0",
+ "prost",
+ "prost-build",
+ "prost-codec",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "serde",
+ "stun",
+ "thiserror",
+ "tinytemplate",
+ "tokio",
+ "tokio-util",
+ "webrtc",
+]
+
+[[package]]
 name = "libp2p-yamux"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6874d66543c4f7e26e3b8ca9a6bead351563a13ab4fafd43c7927f7c0d6c12"
+version = "0.43.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3431,15 +3684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
-dependencies = [
- "hashbrown 0.12.3",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3741,15 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -3509,6 +3762,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3559,15 +3818,15 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
 dependencies = [
  "arrayref",
- "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multibase 0.9.1",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -3617,6 +3876,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+dependencies = [
+ "core2",
+ "digest 0.10.6",
+ "multihash-derive",
+ "sha2 0.10.6",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "multihash-derive"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,8 +3911,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "bytes",
  "futures",
@@ -3727,11 +3998,11 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
- "async-io",
  "bytes",
  "futures",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -3743,6 +4014,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -3759,6 +4031,16 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3850,6 +4132,24 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs 0.3.1",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs 0.5.1",
 ]
 
 [[package]]
@@ -4014,6 +4314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "packed_simd_2"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,10 +4424,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
@@ -4146,7 +4475,7 @@ dependencies = [
  "aes 0.7.5",
  "base64 0.13.1",
  "bitfield",
- "block-modes",
+ "block-modes 0.8.1",
  "block-padding 0.2.1",
  "blowfish",
  "buf_redux",
@@ -4168,7 +4497,7 @@ dependencies = [
  "lazy_static",
  "log",
  "md-5 0.9.1",
- "nom",
+ "nom 4.2.3",
  "num-bigint-dig",
  "num-derive",
  "num-traits",
@@ -4182,7 +4511,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "twofish",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -4283,6 +4612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
  "opaque-debug 0.3.0",
  "universal-hash 0.4.1",
 ]
@@ -4481,9 +4821,8 @@ dependencies = [
 
 [[package]]
 name = "prost-codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
+version = "0.3.0"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4526,6 +4865,33 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.8",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
 
 [[package]]
 name = "quote"
@@ -4611,6 +4977,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "x509-parser 0.13.2",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "yasna",
 ]
 
 [[package]]
@@ -4737,7 +5128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -4870,19 +5261,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1919efd6d4a6a85d13388f9487549bb8e359f17198cc03ffd72f79b553873691"
+dependencies = [
+ "bytes",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
- "async-global-executor",
  "futures",
  "log",
  "netlink-packet-route",
  "netlink-proto",
  "nix",
  "thiserror",
+ "tokio",
 ]
+
+[[package]]
+name = "rtp"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a095411ff00eed7b12e4c6a118ba984d113e1079582570d56a5ee723f11f80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -4891,6 +5313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4962,8 +5393,7 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 [[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+source = "git+https://github.com/kckeiks/rust-libp2p/?branch=use-quick-protobuf#ec86e1f44feac97559b1b786560dc6b7639d8664"
 dependencies = [
  "futures",
  "pin-project",
@@ -5033,6 +5463,18 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sdp"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22a5ef407871893fd72b4562ee15e4742269b173959db4b8df6f538c414e13"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -5713,7 +6155,7 @@ dependencies = [
  "chrono",
  "flate2",
  "libipld",
- "multihash",
+ "multihash 0.16.3",
  "reqwest",
  "serde",
  "serde_json",
@@ -5780,6 +6222,34 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "stun"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
+dependencies = [
+ "base64 0.13.1",
+ "crc",
+ "lazy_static",
+ "md-5 0.10.5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "subtle"
@@ -5960,6 +6430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5986,6 +6466,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6228,6 +6709,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
+ "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -6260,6 +6742,25 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "turn"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "futures",
+ "log",
+ "md-5 0.10.5",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
 
 [[package]]
 name = "twofish"
@@ -6446,6 +6947,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6582,6 +7092,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3bc9049bdb2cea52f5fd4f6f728184225bdb867ed0dc2410eab6df5bdd67bb"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls 0.19.1",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "stun",
+ "thiserror",
+ "time 0.3.17",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef36a4d12baa6e842582fe9ec16a57184ba35e1a09308307b67d43ec8883100"
+dependencies = [
+ "bytes",
+ "derive_builder 0.11.2",
+ "log",
+ "thiserror",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7021987ae0a2ed6c8cd33f68e98e49bb6e74ffe9543310267b48a1bbe3900e5f"
+dependencies = [
+ "aes 0.6.0",
+ "aes-gcm 0.8.0",
+ "async-trait",
+ "bincode",
+ "block-modes 0.7.0",
+ "byteorder",
+ "ccm",
+ "curve25519-dalek 3.2.0",
+ "der-parser 8.1.0",
+ "elliptic-curve",
+ "hkdf",
+ "hmac 0.10.1",
+ "log",
+ "oid-registry 0.6.1",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen 0.9.3",
+ "ring",
+ "rustls 0.19.1",
+ "sec1",
+ "serde",
+ "sha-1",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webpki 0.21.4",
+ "webrtc-util",
+ "x25519-dalek 2.0.0-pre.1",
+ "x509-parser 0.13.2",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494483fbb2f5492620871fdc78b084aed8807377f6e3fe88b2e49f0a9c9c41d7"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
+dependencies = [
+ "log",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a3c157a040324e5049bcbd644ffc9079e6738fa2cfab2bcff64e5cc4c00d7"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "derive_builder 0.11.2",
+ "displaydoc",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d47adcd9427eb3ede33d5a7f3424038f63c965491beafcc20bc650a2f6679c0"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6183edc4c1c6c0175f8812eefdce84dfa0aea9c3ece71c2bf6ddd3c964de3da5"
+dependencies = [
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "aes-gcm 0.9.4",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "ctr 0.8.0",
+ "hmac 0.11.0",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha-1",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cc",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -6811,6 +7533,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser 7.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.4.0",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser 8.1.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6835,6 +7605,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
+dependencies = [
+ "time 0.3.17",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hyper = "0.14" # Prometheus server
 iri-string = "0.5"
 lazy_static = "1.4.0"
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "dag-json", "derive", "serde-codec"]}
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.49.0" }
+libp2p = { default-features = false, features = ["tcp", "mplex", "noise", "ping", "yamux", "dns", "tokio"], version = "0.51.0", git = "https://github.com/kckeiks/rust-libp2p/", branch = "use-quick-protobuf" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio", "reqwest_collector_client"] }
 pin-project = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4"
 hyper = "0.14" # Prometheus server
 iri-string = "0.5"
 lazy_static = "1.4.0"
-libipld = "0.14"
+libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "dag-json", "derive", "serde-codec"]}
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.49.0" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio", "reqwest_collector_client"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG DIR
 WORKDIR $DIR
 COPY --from=builder ${DIR}/target/x86_64-unknown-linux-musl/release/kepler /usr/local/bin/
 COPY ./kepler.toml ./
-ENV KEPLER_ADDRESS=0.0.0.0
+ENV ROCKET_ADDRESS=0.0.0.0
 EXPOSE 8000
 EXPOSE 8001
 EXPOSE 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG DIR
 WORKDIR $DIR
 COPY --from=builder ${DIR}/target/x86_64-unknown-linux-musl/release/kepler /usr/local/bin/
 COPY ./kepler.toml ./
-ENV ROCKET_ADDRESS=0.0.0.0
+ENV KEPLER_ADDRESS=0.0.0.0
 EXPOSE 8000
 EXPOSE 8001
 EXPOSE 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,31 @@
-ARG DIR=/kepler
-ARG BASE_IMAGE=ekidd/rust-musl-builder
-
-# Dependencies cache
-FROM $BASE_IMAGE as dep_planner
-ARG DIR
-WORKDIR $DIR
+FROM clux/muslrust:stable AS chef
 USER root
-RUN chown -R rust:rust .
-USER rust
 RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
 COPY ./Cargo.lock ./
 COPY ./Cargo.toml ./
 COPY ./sdk-wasm/ ./sdk-wasm/
 COPY ./src/ ./src/
 COPY ./lib/ ./lib/
 COPY ./sdk/ ./sdk/
-RUN cargo chef prepare  --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json
 
-FROM $BASE_IMAGE as dep_cacher
-ARG DIR
-WORKDIR $DIR
-USER root
-RUN chown -R rust:rust .
-USER rust
-RUN cargo install cargo-chef
-COPY --from=dep_planner ${DIR}/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+COPY --from=planner /app/ ./
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin kepler
 
-FROM $BASE_IMAGE as builder
-ARG DIR
-WORKDIR $DIR
-USER root
-RUN chown -R rust:rust .
-USER rust
-COPY --from=dep_planner ${DIR}/ ./
-COPY --from=dep_cacher ${DIR}/target/ ./target/
-COPY --from=dep_cacher $CARGO_HOME $CARGO_HOME
-RUN cargo build --release
-
-FROM alpine
-ARG DIR
-WORKDIR $DIR
-COPY --from=builder ${DIR}/target/x86_64-unknown-linux-musl/release/kepler /usr/local/bin/
+FROM alpine AS runtime
+RUN addgroup -S kepler && adduser -S kepler -G kepler
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/kepler /usr/local/bin/kepler
+USER kepler
 COPY ./kepler.toml ./
 ENV ROCKET_ADDRESS=0.0.0.0
 EXPOSE 8000
 EXPOSE 8001
 EXPOSE 8081
-ENTRYPOINT ["kepler"]
+CMD ["kepler"]
 LABEL org.opencontainers.image.source https://github.com/spruceid/kepler

--- a/kepler.toml
+++ b/kepler.toml
@@ -1,17 +1,17 @@
 [global]
 # log_level = "normal"
-# address = 127.0.0.1
-# port = 8000
+address = "127.0.0.1"
+port = 8000
 
 ## Example of nest config variable: KEPLER_DATABASE_PATH
 [global.storage]
     ###### Document shared aws config (`aws_config::from_env()`)
     [global.storage.blocks]
-    # type = "Local"
-    # path = "/tmp/kepler/blocks"
+    type = "Local"
+    path = "./tmp/kepler/blocks"
     [global.storage.indexes]
-    # type = "Local"
-    # path = "/tmp/kepler/indexes"
+    type = "Local"
+    path = "./tmp/kepler/indexes"
 
 [global.orbits]
 ## Orbit allow list api endpoint

--- a/kepler.toml
+++ b/kepler.toml
@@ -1,17 +1,17 @@
 [global]
 # log_level = "normal"
-address = "127.0.0.1"
-port = 8000
+# address = "127.0.0.1"
+# port = 8000
 
 ## Example of nest config variable: KEPLER_DATABASE_PATH
 [global.storage]
     ###### Document shared aws config (`aws_config::from_env()`)
     [global.storage.blocks]
-    type = "Local"
-    path = "./tmp/kepler/blocks"
+    # type = "Local"
+    # path = "/tmp/kepler/blocks"
     [global.storage.indexes]
-    type = "Local"
-    path = "./tmp/kepler/indexes"
+    # type = "Local"
+    # path = "/tmp/kepler/indexes"
 
 [global.orbits]
 ## Orbit allow list api endpoint

--- a/lib/src/resolver.rs
+++ b/lib/src/resolver.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
                 Ok(url) => Some(url),
                 Err(VarError::NotPresent) => None,
                 Err(VarError::NotUnicode(err)) => {
-                    eprintln!("Unable to parse DID_ONION_PROXY_URL: {:?}", err);
+                    eprintln!("Unable to parse DID_ONION_PROXY_URL: {err:?}");
                     None
                 }
             } {

--- a/lib/src/resource.rs
+++ b/lib/src/resource.rs
@@ -61,7 +61,7 @@ impl OrbitId {
                 if p.starts_with('/') {
                     p
                 } else {
-                    format!("/{}", p)
+                    format!("/{p}")
                 }
             }),
             fragment,
@@ -147,7 +147,7 @@ impl TryInto<Capability> for ResourceId {
             ))),
             can: UcanScope {
                 namespace: match self.service {
-                    Some(s) => format!("kepler.{}", s),
+                    Some(s) => format!("kepler.{s}"),
                     None => "kepler".to_string(),
                 },
                 capability: self.fragment.ok_or(ResourceCapErr::MissingAction)?,
@@ -196,13 +196,13 @@ impl fmt::Display for ResourceId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &self.orbit)?;
         if let Some(s) = &self.service {
-            write!(f, "/{}", s)?
+            write!(f, "/{s}")?
         };
         if let Some(p) = &self.path {
-            write!(f, "{}", p)?
+            write!(f, "{p}")?
         };
         if let Some(fr) = &self.fragment {
-            write!(f, "#{}", fr)?
+            write!(f, "#{fr}")?
         };
         Ok(())
     }
@@ -273,7 +273,7 @@ impl FromStr for ResourceId {
                     id: host.into(),
                 },
                 service: path.map(|(s, _)| s.into()),
-                path: path.map(|(_, pa)| format!("/{}", pa)),
+                path: path.map(|(_, pa)| format!("/{pa}")),
                 fragment: uri.fragment().map(|s| s.to_string()),
             }),
             _ => Err(Self::Err::IncorrectForm),

--- a/sdk/src/serde_siwe.rs
+++ b/sdk/src/serde_siwe.rs
@@ -8,7 +8,7 @@ pub mod address {
     {
         String::deserialize(d).and_then(|address| {
             <[u8; 20]>::from_hex(address.strip_prefix("0x").unwrap_or(&address))
-                .map_err(|e| D::Error::custom(format!("failed to parse ethereum: {}", e)))
+                .map_err(|e| D::Error::custom(format!("failed to parse ethereum: {e}")))
         })
     }
 }
@@ -25,7 +25,7 @@ pub mod signature {
         String::deserialize(d).and_then(|sig| {
             <[u8; 65]>::from_hex(sig.strip_prefix("0x").unwrap_or(&sig))
                 .map(Into::into)
-                .map_err(|e| D::Error::custom(format!("failed to parse SIWE signature: {}", e)))
+                .map_err(|e| D::Error::custom(format!("failed to parse SIWE signature: {e}")))
         })
     }
 }

--- a/sdk/src/session.rs
+++ b/sdk/src/session.rs
@@ -80,7 +80,7 @@ impl SessionConfig {
         use serde_json::Value;
         let ns = "kepler"
             .parse()
-            .map_err(|e| format!("error parsing kepler as Siwe Capability namespace: {}", e))?;
+            .map_err(|e| format!("error parsing kepler as Siwe Capability namespace: {e}"))?;
         let b = self
             .actions
             .into_iter()
@@ -121,10 +121,10 @@ impl SessionConfig {
             resources: vec![],
             uri: delegate
                 .try_into()
-                .map_err(|e| format!("failed to parse session key DID as a URI: {}", e))?,
+                .map_err(|e| format!("failed to parse session key DID as a URI: {e}"))?,
             version: SIWEVersion::V1,
         })
-        .map_err(|e| format!("error building Host SIWE message: {}", e))
+        .map_err(|e| format!("error building Host SIWE message: {e}"))
     }
 }
 

--- a/sdk/src/siwe_utils.rs
+++ b/sdk/src/siwe_utils.rs
@@ -43,7 +43,7 @@ impl TryFrom<HostConfig> for Message {
             .with_action(
                 &"kepler"
                     .parse()
-                    .map_err(|e| format!("failed to parse kepler as namespace: {}", e))?,
+                    .map_err(|e| format!("failed to parse kepler as namespace: {e}"))?,
                 c.orbit_id.to_resource(None, None, None).to_string(),
                 "host".to_string(),
             )
@@ -54,7 +54,7 @@ impl TryFrom<HostConfig> for Message {
                 issued_at: c.issued_at,
                 uri: format!("peer:{}", c.peer_id)
                     .try_into()
-                    .map_err(|e| format!("error parsing peer as a URI: {}", e))?,
+                    .map_err(|e| format!("error parsing peer as a URI: {e}"))?,
                 nonce: generate_nonce(),
                 statement: None,
                 resources: vec![],
@@ -63,7 +63,7 @@ impl TryFrom<HostConfig> for Message {
                 expiration_time: None,
                 request_id: None,
             })
-            .map_err(|e| format!("error building Host SIWE message: {}", e))
+            .map_err(|e| format!("error building Host SIWE message: {e}"))
     }
 }
 

--- a/sdk/src/util.rs
+++ b/sdk/src/util.rs
@@ -1,11 +1,10 @@
 pub fn make_orbit_id_pkh_eip155(address: String, chain_id: u32, name: Option<String>) -> String {
-    make_orbit_id(format!("pkh:eip155:{}:{}", chain_id, address), name)
+    make_orbit_id(format!("pkh:eip155:{chain_id}:{address}"), name)
 }
 
 fn make_orbit_id(did_suffix: String, name: Option<String>) -> String {
     format!(
-        "kepler:{}://{}",
-        did_suffix,
+        "kepler:{did_suffix}://{}",
         name.unwrap_or_else(|| String::from("default"))
     )
 }

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -93,7 +93,7 @@ fn extract_siwe_cap(c: SiweCap) -> Result<(Vec<Capability>, Vec<Cid>), CapExtrac
                 .collect::<Vec<(&str, &serde_json::Value)>>()[..]
             {
                 [] => vec![],
-                [("parents", &serde_json::Value::Array(ref a))] => a
+                [("parents", serde_json::Value::Array(a))] => a
                     .iter()
                     .map(|s| {
                         s.as_str()

--- a/src/indexes/heads.rs
+++ b/src/indexes/heads.rs
@@ -22,11 +22,11 @@ impl HeadStore {
             heights: KV::new(
                 orbit_id,
                 subsystem_name.clone(),
-                format!("{}-heights", name),
+                format!("{name}-heights"),
                 config.clone(),
             )
             .await?,
-            heads: KV::new(orbit_id, subsystem_name, format!("{}-heads", name), config).await?,
+            heads: KV::new(orbit_id, subsystem_name, format!("{name}-heads"), config).await?,
         })
     }
     pub async fn get_heads(&self) -> Result<(Vec<Cid>, u64)> {
@@ -52,7 +52,6 @@ impl HeadStore {
                 Ok((heads, u64::max(max_height, height)))
             },
         )
-        // .collect()
         .await
     }
 

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -74,7 +74,7 @@ struct Element(pub u64, pub Cid);
 #[derive(thiserror::Error, Debug)]
 enum ElementDeserError {
     #[error(transparent)]
-    Cid(#[from] libipld::cid::Error),
+    Cid(#[from] kepler_lib::libipld::cid::Error),
     #[error("Insufficient bytes")]
     Length,
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -175,7 +175,7 @@ where
                 .map_err(|e| {
                     (
                         Status::InternalServerError,
-                        format!("Failed to delete content: {}", e),
+                        format!("Failed to delete content: {e}"),
                     )
                 })?;
             Ok(InvocationResponse::EmptySuccess)

--- a/src/storage/indexes.rs
+++ b/src/storage/indexes.rs
@@ -134,7 +134,7 @@ impl KV {
                     }) => match output.get(VALUE_ATTRIBUTE) {
                         Some(AttributeValue::B(blob)) => Ok(Some(blob.clone().into_inner())),
                         Some(_) => Err(anyhow!("Wrong type for value")),
-                        None => Err(anyhow!("No `{}` column", KEY_ATTRIBUTE)),
+                        None => Err(anyhow!("No `{KEY_ATTRIBUTE}` column")),
                     },
                     Ok(_) => Ok(None),
                     Err(e) => Err(anyhow!("Error checking on item: {}", e)),
@@ -182,7 +182,7 @@ impl KV {
                             c.orbit, c.subsystem, c.prefix, "elements"
                         )),
                     )
-                    .update_expression(format!("ADD {} :elements", ELEMENTS_ATTRIBUTE,))
+                    .update_expression(format!("ADD {ELEMENTS_ATTRIBUTE} :elements"))
                     .expression_attribute_values(
                         ":elements",
                         AttributeValue::Ss(vec![hex::encode(key)]),
@@ -246,7 +246,7 @@ impl KV {
                             c.orbit, c.subsystem, c.prefix, "elements"
                         )),
                     )
-                    .update_expression(format!("DELETE {} :elements", ELEMENTS_ATTRIBUTE,))
+                    .update_expression(format!("DELETE {ELEMENTS_ATTRIBUTE} :elements"))
                     .expression_attribute_values(
                         ":elements",
                         AttributeValue::Ss(batch.into_iter().map(hex::encode).collect()),

--- a/src/storage/utils.rs
+++ b/src/storage/utils.rs
@@ -53,7 +53,6 @@ macro_rules! write_with_multihash {
                 let (mut h, b) = hb.into_inner();
                 Ok((Code::$hashes.wrap(h.finalize())?, b))
             },)*
-            c => Err(MultihashError::UnsupportedCode(c.into()))
         }
     };
 }

--- a/src/storage/utils.rs
+++ b/src/storage/utils.rs
@@ -5,7 +5,7 @@ use futures::{
     io::{copy, AsyncRead, AsyncWrite, AsyncWriteExt},
     task::{Context, Poll},
 };
-use libipld::cid::multihash::{
+use kepler_lib::libipld::cid::multihash::{
     Blake2b256, Blake2b512, Blake2s128, Blake2s256, Blake3_256, Code, Error as MultihashError,
     Hasher, Keccak224, Keccak256, Keccak384, Keccak512, Multihash, MultihashDigest, Sha2_256,
     Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -40,7 +40,7 @@ impl Fairing for TracingFairing {
         if let Some(TracingSpan(span)) = req.local_cache(|| Option::<TracingSpan>::None).to_owned()
         {
             let trace_id = span.context().span().span_context().trace_id();
-            res.set_raw_header(self.header_name.clone(), format!("{}", trace_id));
+            res.set_raw_header(self.header_name.clone(), format!("{trace_id}"));
         }
     }
 }


### PR DESCRIPTION
# Description

Docker builds have been broken by the [rate limiting of `protoc`](https://github.com/libp2p/rust-libp2p/pull/3199) builds from the Github api stemming from it's (unavoidable) use in libp2p, as well as some other issues. This PR swaps to a branch of libp2p which removes the dependancy on `protoc` in favour of a pure rust impl. This is not a perfect fix, once the [corresponding libp2p PR](https://github.com/libp2p/rust-libp2p/pull/3066) is merged this branch will disappear and another PR will be needed to go back to libp2p trunk. Another option is to fully remove libp2p for now, but this would entail a number of breaking changes.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
