### PR TITLE
expose headers

### DIFF
--- a/kepler.toml
+++ b/kepler.toml
@@ -2,6 +2,7 @@
 # log_level = "normal"
 # address = "127.0.0.1"
 # port = 8000
+# cors = true
 
 ## Example of nest config variable: KEPLER_DATABASE_PATH
 [global.storage]

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub orbits: OrbitsConfig,
     pub relay: Relay,
     pub prometheus: Prometheus,
+    pub cors: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,14 +96,17 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
             Box::pin(async move {
                 resp.set_header(Header::new("Access-Control-Allow-Origin", "*"));
                 resp.set_header(Header::new(
+                    // allow these methods for requests
                     "Access-Control-Allow-Methods",
                     "POST, PUT, GET, OPTIONS, DELETE",
                 ));
                 resp.set_header(Header::new(
+                    // expose response headers to browser-run scripts
                     "Access-Control-Expose-Headers",
                     "*, Authorization",
                 ));
                 resp.set_header(Header::new(
+                    // allow custom headers + Authorization in requests
                     "Access-Control-Allow-Headers",
                     "*, Authorization",
                 ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,14 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
                     "Access-Control-Allow-Methods",
                     "POST, PUT, GET, OPTIONS, DELETE",
                 ));
-                resp.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+                resp.set_header(Header::new(
+                    "Access-Control-Expose-Headers",
+                    "*, Authorization",
+                ));
+                resp.set_header(Header::new(
+                    "Access-Control-Allow-Headers",
+                    "*, Authorization",
+                ));
                 resp.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
             })
         }))


### PR DESCRIPTION
# Description

Clients running within the browser have been unable to inspect the headers of responses from Kepler. The headers are present, but the [CORS header `Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) was not set, preventing browser scripts from accessing them. This left only the `content-type` header available for clients running in the browser. This PR adds the aforementioned CORS header to allow clients to see the response headers. It is configurable with the `cors` config option, either `true` or `false`. I tried to make it more granular with all the cors options but it couldn't solve lifetime issues quickly enough.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# System Configuration

(Please delete options that are not relevant)  
Browser version(s):  All except safari
SDK version(s): 0.12.1

# Diligence Checklist

(Please delete options that are not relevant)

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
