### PR TITLE
Content length from store

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,8 +24,9 @@ pub struct Logging {
     pub tracing: Tracing,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub enum LoggingFormat {
+    #[default]
     Text,
     Json,
 }
@@ -95,12 +96,6 @@ impl Default for Tracing {
             enabled: false,
             traceheader: "Spruce-Trace-Id".to_string(),
         }
-    }
-}
-
-impl Default for LoggingFormat {
-    fn default() -> LoggingFormat {
-        LoggingFormat::Text
     }
 }
 

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -188,7 +188,7 @@ where
             _ => return Ok(None),
         };
         match self.blocks.read(kv_obj.value.hash()).await? {
-            Some(r) => Ok(Some(ReadResponse(kv_obj.metadata, r))),
+            Some(r) => Ok(Some(ReadResponse(kv_obj.metadata, r.into_inner().1))),
             None => Err(anyhow!("Indexed contents missing from block store")),
         }
     }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1,6 +1,6 @@
 use crate::indexes::{AddRemoveSetStore, HeadStore};
 use crate::kv::{Object, ObjectBuilder, Service};
-use crate::storage::ImmutableStore;
+use crate::storage::{Content, ImmutableStore};
 use anyhow::Result;
 use futures::{
     io::AsyncRead,
@@ -179,7 +179,7 @@ where
     }
 
     #[instrument(name = "kv::read", skip_all)]
-    pub async fn read<N>(&self, key: N) -> Result<Option<ReadResponse<B::Readable>>>
+    pub async fn read<N>(&self, key: N) -> Result<Option<ReadResponse<Content<B::Readable>>>>
     where
         N: AsRef<[u8]>,
     {
@@ -188,7 +188,7 @@ where
             _ => return Ok(None),
         };
         match self.blocks.read(kv_obj.value.hash()).await? {
-            Some(r) => Ok(Some(ReadResponse(kv_obj.metadata, r.into_inner().1))),
+            Some(r) => Ok(Some(ReadResponse(kv_obj.metadata, r))),
             None => Err(anyhow!("Indexed contents missing from block store")),
         }
     }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     authorization::{Capability, Delegation},
     kv::{ObjectBuilder, ReadResponse},
     relay::RelayNode,
-    storage::ImmutableStore,
+    storage::{Content, ImmutableStore},
     tracing::TracingSpan,
     BlockStores,
 };
@@ -132,7 +132,8 @@ pub async fn invoke(
     i: InvokeAuthWrapper<BlockStores>,
     req_span: TracingSpan,
     data: Data<'_>,
-) -> Result<InvocationResponse<<BlockStores as ImmutableStore>::Readable>, (Status, String)> {
+) -> Result<InvocationResponse<Content<<BlockStores as ImmutableStore>::Readable>>, (Status, String)>
+{
     let action_label = i.prometheus_label().to_string();
     let span = info_span!(parent: &req_span.0, "invoke", action = %action_label);
     // Instrumenting async block to handle yielding properly
@@ -157,7 +158,7 @@ pub async fn invoke(
 pub async fn handle_kv_action<B>(
     action: KVAction<B>,
     data: Data<'_>,
-) -> Result<InvocationResponse<B::Readable>, (Status, String)>
+) -> Result<InvocationResponse<Content<B::Readable>>, (Status, String)>
 where
     B: 'static + ImmutableStore,
 {
@@ -240,7 +241,7 @@ where
 pub async fn handle_cap_action<B>(
     action: CapAction<B>,
     _data: Data<'_>,
-) -> Result<InvocationResponse<B::Readable>, (Status, String)>
+) -> Result<InvocationResponse<Content<B::Readable>>, (Status, String)>
 where
     B: 'static + ImmutableStore,
 {

--- a/src/storage/file_system.rs
+++ b/src/storage/file_system.rs
@@ -1,6 +1,6 @@
 use crate::{
     orbit::ProviderUtils,
-    storage::{utils::copy_in, ImmutableStore, KeyedWriteError, StorageConfig},
+    storage::{utils::copy_in, Content, ImmutableStore, KeyedWriteError, StorageConfig},
 };
 use kepler_lib::{
     libipld::cid::{
@@ -189,9 +189,9 @@ impl ImmutableStore for FileSystemStore {
             Err(e) => Err(e.into()),
         }
     }
-    async fn read(&self, id: &Multihash) -> Result<Option<Self::Readable>, Self::Error> {
+    async fn read(&self, id: &Multihash) -> Result<Option<Content<Self::Readable>>, Self::Error> {
         match File::open(self.get_path(id)).await {
-            Ok(f) => Ok(Some(f.compat())),
+            Ok(f) => Ok(Some(Content::new(f.metadata().await?.len(), f.compat()))),
             Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
             Err(e) => Err(e.into()),
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -53,6 +53,10 @@ impl<R> Content<R> {
         self.0
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
     pub fn into_inner(self) -> (u64, R) {
         (self.0, self.1)
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,23 +42,27 @@ pub enum KeyedWriteError<E> {
 
 #[pin_project]
 #[derive(Debug)]
-pub struct Content<R>(u64, #[pin] R);
+pub struct Content<R> {
+    size: u64,
+    #[pin]
+    content: R,
+}
 
 impl<R> Content<R> {
     pub fn new(size: u64, content: R) -> Self {
-        Self(size, content)
+        Self { size, content }
     }
 
     pub fn len(&self) -> u64 {
-        self.0
+        self.size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0 == 0
+        self.len() == 0
     }
 
     pub fn into_inner(self) -> (u64, R) {
-        (self.0, self.1)
+        (self.size, self.content)
     }
 }
 
@@ -72,7 +76,7 @@ where
         buf: &mut [u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
         let this = self.project();
-        this.1.poll_read(cx, buf)
+        this.content.poll_read(cx, buf)
     }
 
     fn poll_read_vectored(
@@ -81,7 +85,7 @@ where
         bufs: &mut [std::io::IoSliceMut<'_>],
     ) -> std::task::Poll<std::io::Result<usize>> {
         let this = self.project();
-        this.1.poll_read_vectored(cx, bufs)
+        this.content.poll_read_vectored(cx, bufs)
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -121,7 +121,7 @@ pub trait ImmutableStore: Send + Sync {
             None => return Ok(None),
             Some(r) => r.into_inner(),
         };
-        let mut v = vec![0u8; l as usize];
+        let mut v = Vec::with_capacity(l as usize);
         Box::pin(r)
             .read_to_end(&mut v)
             .await


### PR DESCRIPTION
# Description

Currently we cannot easily find the size of an entry in an ImmutableStore. This PR wraps responses from the store in a Content struct which holds the length and can be expanded with additional useful fields in the future. This assists with setting the content-length on responses and will be useful for p2p communication when exchanging stored contents.

# Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
