### PR TITLE
Fix invocation expiry time

### DIFF
--- a/sdk/src/session.rs
+++ b/sdk/src/session.rs
@@ -141,6 +141,7 @@ impl Session {
         let now = OffsetDateTime::now_utc();
         let nanos = now.nanosecond();
         let unix = now.unix_timestamp();
+        // 60 seconds in the future
         let exp = (unix.seconds() + Duration::nanoseconds(nanos.into()) + Duration::MINUTE)
             .as_seconds_f64();
         make_invocation(
@@ -148,7 +149,6 @@ impl Session {
             self.delegation_cid,
             &self.jwk,
             self.verification_method,
-            // 60 seconds in the future
             exp,
             None,
             None,

--- a/sdk/src/session.rs
+++ b/sdk/src/session.rs
@@ -15,7 +15,7 @@ use kepler_lib::{
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::collections::HashMap;
-use time::OffsetDateTime;
+use time::{ext::NumericalDuration, Duration, OffsetDateTime};
 
 #[serde_as]
 #[derive(Deserialize, Clone)]
@@ -138,13 +138,18 @@ impl Session {
         let target = self
             .orbit_id
             .to_resource(Some(service), Some(path), Some(action));
+        let now = OffsetDateTime::now_utc();
+        let nanos = now.nanosecond();
+        let unix = now.unix_timestamp();
+        let exp = (unix.seconds() + Duration::nanoseconds(nanos.into()) + Duration::MINUTE)
+            .as_seconds_f64();
         make_invocation(
             target,
             self.delegation_cid,
             &self.jwk,
             self.verification_method,
             // 60 seconds in the future
-            (OffsetDateTime::now_utc().nanosecond() as f64 / 1e+9_f64) + 60.0,
+            exp,
             None,
             None,
         )

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -121,7 +121,7 @@ impl<B> Store<B> {
     }
 
     #[instrument(name = "kv::list", skip_all)]
-    pub async fn list(&self) -> impl Iterator<Item = Result<Vec<u8>>> + '_ {
+    pub async fn list(&self) -> impl Iterator<Item = Result<Vec<u8>>> {
         let elements = match self.index.elements().await {
             Ok(e) => e,
             Err(e) => return vec![Err(e)].into_iter(),


### PR DESCRIPTION
# Description

Currently the invocation expiry time is calculated to be (in unix seconds) 60 + the nanosecond offset of `now`. This is incorrect, it should be `now` + 60. This PR fixes it

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
