### PR TITLE
test docker compose must include secrets config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "kepler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.9",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@ impl From<BlockConfig> for BlockStorage {
 impl From<StagingStorage> for BlockStage {
     fn from(c: StagingStorage) -> Self {
         match c {
-            StagingStorage::Memory => Self::B(MemoryStaging::default()),
-            StagingStorage::FileSystem => Self::A(TempFileSystemStage::default()),
+            StagingStorage::Memory => Self::B(MemoryStaging),
+            StagingStorage::FileSystem => Self::A(TempFileSystemStage),
         }
     }
 }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       KEPLER_STORAGE_BLOCKS_TYPE: S3
       KEPLER_STORAGE_BLOCKS_ENDPOINT: "http://localstack:4566"
       KEPLER_STORAGE_DATABASE: "postgres://postgres:postgres@postgres:5432/postgres"
+      KEPLER_KEYS_TYPE: "Static"
+      KEPLER_KEYS_SECRET: "U29tZSBsb25nIHBpZWNlIG9mIGVudHJvcHkgd2hpY2ggaXMgYSBzZWNyZXQgYW5kIG1vcmUgdGhhbiAzMiBieXRlcw"
       AWS_ACCESS_KEY_ID: "test"
       AWS_SECRET_ACCESS_KEY: "test"
       AWS_DEFAULT_REGION: "us-east-1"


### PR DESCRIPTION
# Description

Small fix for the test docker compose file, the secret and keys type must be provided as env vars.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
