### PR TITLE
fix duplicate del/inv/rev insertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "kepler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.9",


### PR DESCRIPTION
# Description

re-using a delegation/invocation/revocation should be accepted and not throw an error, except in the case of verification failing or revocation having been applied to a parent. currently kepler will have a conflict in the DB upon insertion of the row into the table. this PR sets such conflicts to not throw an error, but still applies the other verification rules, so re-use of the token will be either a verification error or a no-op.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
