### PR TITLE
use did:key for peer IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "kepler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-sdk-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.9",

--- a/kepler-core/src/db.rs
+++ b/kepler-core/src/db.rs
@@ -1,6 +1,6 @@
 use crate::events::{epoch_hash, Delegation, Event, HashError, Invocation, Operation, Revocation};
 use crate::hash::Hash;
-use crate::keys::Secrets;
+use crate::keys::{get_did_key, Secrets};
 use crate::migrations::Migrator;
 use crate::models::*;
 use crate::relationships::*;
@@ -14,7 +14,6 @@ use kepler_lib::{
     authorization::{EncodingError, KeplerDelegation},
     resource::OrbitId,
 };
-use libp2p::identity::PublicKey;
 use sea_orm::{
     entity::prelude::*,
     error::{DbErr, RuntimeErr, SqlxError},
@@ -117,8 +116,8 @@ impl<C, B, K> OrbitDatabase<C, B, K>
 where
     K: Secrets,
 {
-    pub async fn stage_key(&self, orbit: &OrbitId) -> Result<PublicKey, K::Error> {
-        self.secrets.stage_keypair(orbit).await
+    pub async fn stage_key(&self, orbit: &OrbitId) -> Result<String, K::Error> {
+        self.secrets.stage_keypair(orbit).await.map(get_did_key)
     }
 }
 

--- a/kepler-core/src/keys.rs
+++ b/kepler-core/src/keys.rs
@@ -2,15 +2,28 @@ use kepler_lib::{
     libipld::cid::multihash::{Blake3_256, Hasher},
     resource::OrbitId,
 };
-use libp2p::{
-    identity::{
-        ed25519::{Keypair as EdKP, SecretKey},
-        DecodingError, Keypair, PublicKey,
-    },
-    PeerId,
+use libp2p::identity::{
+    ed25519::{Keypair as EdKP, SecretKey},
+    DecodingError,
 };
 use sea_orm_migration::async_trait::async_trait;
 use std::error::Error as StdError;
+
+pub use libp2p::{
+    identity::{Keypair, PublicKey},
+    PeerId,
+};
+
+pub(crate) fn get_did_key(key: PublicKey) -> String {
+    use kepler_lib::libipld::cid::multibase;
+    // only ed25519 feature is enabled, so this unwrap should never fail
+    let ed25519_pk_bytes = key.try_into_ed25519().unwrap().to_bytes();
+    let multicodec_pk = [[0xed].as_slice(), ed25519_pk_bytes.as_slice()].concat();
+    format!(
+        "did:key:{}",
+        multibase::encode(multibase::Base::Base58Btc, multicodec_pk)
+    )
+}
 
 #[async_trait]
 pub trait Secrets {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -35,7 +35,7 @@ pub async fn open_host_key(
     s: &State<Kepler>,
     orbit: &str,
 ) -> Result<String, (Status, &'static str)> {
-    Ok(s.stage_key(
+    s.stage_key(
         &orbit
             .parse()
             .map_err(|_| (Status::BadRequest, "Invalid orbit ID"))?,
@@ -46,9 +46,7 @@ pub async fn open_host_key(
             Status::InternalServerError,
             "Failed to stage keypair for orbit",
         )
-    })?
-    .to_peer_id()
-    .to_base58())
+    })
 }
 
 #[post("/delegate")]


### PR DESCRIPTION
# Description

Currently peers are represented in delegations by URIs of the form `peer:<PEER-ID>`, which is neither a proper URI or a DID. This PR adds a way to get a `did:key` DID of a peer. At the moment this is mostly an aesthetic change as we don't use peer IDs, but it's a change we should make before we start using the Peers keys to sign things

# Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
