### PR TITLE
fix peer id -> did uri in sdk

### DIFF
--- a/sdk/src/siwe_utils.rs
+++ b/sdk/src/siwe_utils.rs
@@ -52,7 +52,8 @@ impl TryFrom<HostConfig> for Message {
                 chain_id: c.chain_id,
                 domain: c.domain,
                 issued_at: c.issued_at,
-                uri: format!("peer:{}", c.peer_id)
+                uri: c
+                    .peer_id
                     .try_into()
                     .map_err(|e| format!("error parsing peer as a URI: {e}"))?,
                 nonce: generate_nonce(),


### PR DESCRIPTION
# Description

Pr #151 turned Peer IDs into dids in kepler but not in the SDK, as I forgot to stage a change. This pr fixes that. these changes should not affect any functionality even if kepler is deployed before this pr is merged and makes its way into all the clients.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
