### PR TITLE
slightly improved http error status codes and db health check

### DIFF
--- a/kepler-core/src/db.rs
+++ b/kepler-core/src/db.rs
@@ -142,6 +142,17 @@ where
     }
 }
 
+impl<C, B, K> OrbitDatabase<C, B, K>
+where
+    C: TransactionTrait,
+{
+    pub async fn check_db_connection(&self) -> Result<(), DbErr> {
+        // there's a `ping` method on the connection, but we can't access it from here
+        // but starting a transaction should be enough to check the connection
+        self.conn.begin().await.map(|_| ())
+    }
+}
+
 pub type InvocationInputs<W> = HashMap<(OrbitId, String), (Metadata, HashBuffer<W>)>;
 
 impl<C, B, K> OrbitDatabase<C, B, K>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod tracing;
 use config::{BlockStorage, Config, Keys, StagingStorage};
 use kepler_core::{
     keys::{SecretsSetup, StaticSecret},
-    sea_orm::{Database, DatabaseConnection},
+    sea_orm::{ConnectOptions, Database, DatabaseConnection},
     storage::{either::Either, memory::MemoryStaging, StorageConfig},
     OrbitDatabase,
 };
@@ -86,8 +86,11 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         Keys::Static(s) => s.try_into()?,
     };
 
+    let mut connect_opts = ConnectOptions::from(&kepler_config.storage.database);
+    connect_opts.max_connections(100);
+
     let kepler = Kepler::new(
-        Database::connect(&kepler_config.storage.database).await?,
+        Database::connect(connect_opts).await?,
         kepler_config.storage.blocks.open().await?,
         key_setup.setup(()).await?,
     )

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -69,6 +69,7 @@ pub async fn delegate(
                 (
                     match e {
                         TxError::OrbitNotFound => Status::NotFound,
+                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::ServiceUnavailable,
                         _ => Status::Unauthorized,
                     },
                     e.to_string(),
@@ -183,7 +184,16 @@ pub async fn invoke(
                     _ => unreachable!(),
                 },
             )
-            .map_err(|e| (Status::Unauthorized, e.to_string()));
+            .map_err(|e| {
+                (
+                    match e {
+                        TxError::OrbitNotFound => Status::NotFound,
+                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::ServiceUnavailable,
+                        _ => Status::Unauthorized,
+                    },
+                    e.to_string(),
+                )
+            });
 
         timer.observe_duration();
         res

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -69,7 +69,7 @@ pub async fn delegate(
                 (
                     match e {
                         TxError::OrbitNotFound => Status::NotFound,
-                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::ServiceUnavailable,
+                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::InternalServerError,
                         _ => Status::Unauthorized,
                     },
                     e.to_string(),
@@ -188,7 +188,7 @@ pub async fn invoke(
                 (
                     match e {
                         TxError::OrbitNotFound => Status::NotFound,
-                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::ServiceUnavailable,
+                        TxError::DbErr(DbErr::ConnectionAcquire) => Status::InternalServerError,
                         _ => Status::Unauthorized,
                     },
                     e.to_string(),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -24,11 +24,19 @@ use util::LimitedReader;
 
 #[allow(clippy::let_unit_value)]
 pub mod util_routes {
+    use super::*;
+
     #[options("/<_s..>")]
     pub async fn cors(_s: std::path::PathBuf) {}
 
     #[get("/healthz")]
-    pub fn healthcheck() {}
+    pub async fn healthcheck(s: &State<Kepler>) -> Status {
+        if s.check_db_connection().await.is_ok() {
+            Status::Ok
+        } else {
+            Status::InternalServerError
+        }
+    }
 }
 
 #[get("/peer/generate/<orbit>")]


### PR DESCRIPTION
# Description

DB connection failing to be acquired from the connection pool currently results in a `401 unauthorised` status code, when it should probably be a 500 or 503 status. This PR sets it to give a 503 status in this case. not necessarily a bug fix but will be more informative in future. Additionally, this pr sets the max number of connections to 100 (previously defaulted to 10) and adds a db status check to the `/healthz` endpoint.

# Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Diligence Checklist

(Please delete options that are not relevant)

- [ ] This change requires a documentation update
- [ ] I have included unit tests
- [ ] I have updated and/or included new integration tests
- [ ] I have updated and/or included new end-to-end tests
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
